### PR TITLE
Delete all cookbook versions

### DIFF
--- a/lib/between_meals/knife.rb
+++ b/lib/between_meals/knife.rb
@@ -83,7 +83,7 @@ module BetweenMeals
       if cookbooks.any?
         cookbooks.each do |cookbook|
           exec!("#{@knife} cookbook delete #{cookbook.name}" +
-                  " --purge --yes -c #{@config}", @logger)
+                  " --purge -a --yes -c #{@config}", @logger)
         end
       end
     end


### PR DESCRIPTION
GD/TT assumes no versions. If there somehow got multiple versions, we
should not break.