### PR TITLE
support for a berkshelf config and a bug fix

### DIFF
--- a/lib/between_meals/knife.rb
+++ b/lib/between_meals/knife.rb
@@ -77,14 +77,14 @@ module BetweenMeals
 
     def berks_cookbook_upload_all
       if @berks_config
-        @berks_config = '--config=' + @berks_config
+        berks_config = '--config=' + @berks_config
       end
       @cookbook_dirs.each do |path|
         cookbooks = Dir["#{path}/*"].select { |o| File.directory?(o) }
         cookbooks.each do |cb|
           @logger.warn("Running berkshelf on cookbook: #{cb}")
-          exec!("cd #{cb} && #{@berks} install #{@berks_config} && " +
-            "#{@berks} upload #{@berks_config}", @logger)
+          exec!("cd #{cb} && #{@berks} install #{berks_config} && " +
+            "#{@berks} upload #{berks_config}", @logger)
         end
       end
     end
@@ -100,15 +100,15 @@ module BetweenMeals
       # cookbooks: array
       # cookbook_paths: array
       if @berks_config
-        @berks_config = '--config=' + @berks_config
+        berks_config = '--config=' + @berks_config
       end
       if cookbooks.any?
         @cookbook_dirs.each do |path|
           cookbooks.each do |cb|
             next unless File.exists?("#{path}/#{cb}")
             @logger.warn("Running berkshelf on cookbook: #{cb}")
-            exec!("cd #{path}/#{cb} && #{@berks} update #{@berks_config} && " +
-              "#{@berks} upload #{@berks_config}", @logger)
+            exec!("cd #{path}/#{cb} && #{@berks} update #{berks_config} && " +
+              "#{@berks} upload #{berks_config}", @logger)
           end
         end
       end

--- a/lib/between_meals/knife.rb
+++ b/lib/between_meals/knife.rb
@@ -38,6 +38,7 @@ module BetweenMeals
         "#{@home}/.chef/knife-#{@user}-taste-tester.rb"
       @knife = opts[:bin] || 'knife'
       @berks = opts[:berks_bin] || 'berks'
+      @berks_config = opts[:berks_config]
       @pem = opts[:pem] ||
         "#{@home}/.chef/#{@user}-taste-tester.pem"
       @role_dir = opts[:role_dir]

--- a/lib/between_meals/knife.rb
+++ b/lib/between_meals/knife.rb
@@ -38,6 +38,7 @@ module BetweenMeals
         "#{@home}/.chef/knife-#{@user}-taste-tester.rb"
       @knife = opts[:bin] || 'knife'
       @berks = opts[:berks_bin] || 'berks'
+      @berks_config = opts[:berks_config] || ''
       @pem = opts[:pem] ||
         "#{@home}/.chef/#{@user}-taste-tester.pem"
       @role_dir = opts[:role_dir]
@@ -75,12 +76,15 @@ module BetweenMeals
     end
 
     def berks_cookbook_upload_all
+      if @berks_config.length > 0
+        @berks_config = '--config=' + @berks_config
+      end
       @cookbook_dirs.each do |path|
         cookbooks = Dir["#{path}/*"].select { |o| File.directory?(o) }
         cookbooks.each do |cb|
           @logger.warn("Running berkshelf on cookbook: #{cb}")
-          exec!("cd #{path}/#{cb} && #{@berks} install && #{@berks} upload",
-                @logger)
+          exec!("cd #{cb} && #{@berks} install #{@berks_config} && " \
+            "#{@berks} upload #{@berks_config}", @logger)
         end
       end
     end
@@ -95,13 +99,16 @@ module BetweenMeals
     def berks_cookbook_upload(cookbooks)
       # cookbooks: array
       # cookbook_paths: array
+      if @berks_config.length > 0
+        @berks_config = '--config=' + @berks_config
+      end
       if cookbooks.any?
         @cookbook_dirs.each do |path|
           cookbooks.each do |cb|
             next unless File.exists?("#{path}/#{cb}")
             @logger.warn("Running berkshelf on cookbook: #{cb}")
-            exec!("cd #{path}/#{cb} && #{@berks} update && #{@berks} upload",
-              @logger)
+            exec!("cd #{path}/#{cb} && #{@berks} update #{@berks_config} && " \
+              "#{@berks} upload #{@berks_config}", @logger)
           end
         end
       end

--- a/lib/between_meals/knife.rb
+++ b/lib/between_meals/knife.rb
@@ -38,7 +38,6 @@ module BetweenMeals
         "#{@home}/.chef/knife-#{@user}-taste-tester.rb"
       @knife = opts[:bin] || 'knife'
       @berks = opts[:berks_bin] || 'berks'
-      @berks_config = opts[:berks_config] || ''
       @pem = opts[:pem] ||
         "#{@home}/.chef/#{@user}-taste-tester.pem"
       @role_dir = opts[:role_dir]

--- a/lib/between_meals/knife.rb
+++ b/lib/between_meals/knife.rb
@@ -76,7 +76,7 @@ module BetweenMeals
     end
 
     def berks_cookbook_upload_all
-      unless @berks_config.nil?
+      if @berks_config
         @berks_config = '--config=' + @berks_config
       end
       @cookbook_dirs.each do |path|
@@ -99,7 +99,7 @@ module BetweenMeals
     def berks_cookbook_upload(cookbooks)
       # cookbooks: array
       # cookbook_paths: array
-      unless @berks_config.nil?
+      if @berks_config
         @berks_config = '--config=' + @berks_config
       end
       if cookbooks.any?
@@ -107,7 +107,7 @@ module BetweenMeals
           cookbooks.each do |cb|
             next unless File.exists?("#{path}/#{cb}")
             @logger.warn("Running berkshelf on cookbook: #{cb}")
-            exec!("cd #{path}/#{cb} && #{@berks} update #{@berks_config} && " \
+            exec!("cd #{path}/#{cb} && #{@berks} update #{@berks_config} && " +
               "#{@berks} upload #{@berks_config}", @logger)
           end
         end

--- a/lib/between_meals/knife.rb
+++ b/lib/between_meals/knife.rb
@@ -76,14 +76,14 @@ module BetweenMeals
     end
 
     def berks_cookbook_upload_all
-      if @berks_config.length > 0
+      unless @berks_config.nil?
         @berks_config = '--config=' + @berks_config
       end
       @cookbook_dirs.each do |path|
         cookbooks = Dir["#{path}/*"].select { |o| File.directory?(o) }
         cookbooks.each do |cb|
           @logger.warn("Running berkshelf on cookbook: #{cb}")
-          exec!("cd #{cb} && #{@berks} install #{@berks_config} && " \
+          exec!("cd #{cb} && #{@berks} install #{@berks_config} && " +
             "#{@berks} upload #{@berks_config}", @logger)
         end
       end
@@ -99,7 +99,7 @@ module BetweenMeals
     def berks_cookbook_upload(cookbooks)
       # cookbooks: array
       # cookbook_paths: array
-      if @berks_config.length > 0
+      unless @berks_config.nil?
         @berks_config = '--config=' + @berks_config
       end
       if cookbooks.any?


### PR DESCRIPTION
- berkshelf config is necessary when you want to upload to different chef servers as berkshelf will not honor the knife config specified in gd, instead it will look in default locations like ~/.chef/knife.rb. 
- bug fix for `berks_cookbook_upload_all` method, `cb` is already an absolute path and doesn't need the cookbook dir appended. 