### PR TITLE
Make rugged import safe(-ish)

### DIFF
--- a/lib/between_meals/repo/git.rb
+++ b/lib/between_meals/repo/git.rb
@@ -14,7 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
+# Require openssl in order to make rugged work reliably
 require 'openssl'
+
 require 'rugged'
 require 'mixlib/shellout'
 require 'between_meals/changeset'

--- a/lib/between_meals/repo/git.rb
+++ b/lib/between_meals/repo/git.rb
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require 'openssl'
 require 'rugged'
 require 'mixlib/shellout'
 require 'between_meals/changeset'


### PR DESCRIPTION
```
$ irb
irb(main):001:0> require 'rugged'
irb: symbol lookup error: /opt/chef/embedded/lib/ruby/gems/2.1.0/extensions/x86_64-linux/2.1.0/rugged-0.21.4/rugged/rugged.so: undefined symbol: SSL_load_error_strings
$ irb
irb(main):001:0> require 'openssl'
=> true
irb(main):002:0> require 'rugged'
=> true
irb(main):003:0>
```
I don't even.