### PR TITLE
Auto detect repo type

### DIFF
--- a/lib/between_meals/repo/git.rb
+++ b/lib/between_meals/repo/git.rb
@@ -29,7 +29,11 @@ module BetweenMeals
       # see repo.rb for API documentation.
       def setup
         if File.exists?(File.expand_path(@repo_path))
-          @repo = Rugged::Repository.new(File.expand_path(@repo_path))
+          begin
+            @repo = Rugged::Repository.new(File.expand_path(@repo_path))
+          rescue
+            @repo = nil
+          end
         else
           @repo = nil
         end
@@ -37,7 +41,7 @@ module BetweenMeals
       end
 
       def exists?
-        @repo && !@repo.empty?
+        !@repo.nil?
       end
 
       def head_rev

--- a/lib/between_meals/repo/hg.rb
+++ b/lib/between_meals/repo/hg.rb
@@ -28,8 +28,7 @@ module BetweenMeals
       end
 
       def exists?
-        # this should be better
-        Dir.exists?(@repo_path)
+        Dir.exists?(Pathname.new(@repo_path).join('.hg'))
       end
 
       def head_rev

--- a/lib/between_meals/repo/svn.rb
+++ b/lib/between_meals/repo/svn.rb
@@ -29,8 +29,7 @@ module BetweenMeals
       end
 
       def exists?
-        # this shuold be better
-        Dir.exists?(@repo_path)
+        Dir.exists?(Pathname.new(@repo_path).join('.svn'))
       end
 
       def head_rev


### PR DESCRIPTION
This adds automated repo type detection, without breaking the convention of `.setup` always succeeding, and `.exists?` being the actual validation. So it happens that was already broken for git, since rugged was throwing an exception - that is fixed here.

Passes gd and tt full tests.