### PR TITLE
Fix hg amend

### DIFF
--- a/lib/between_meals/repo/hg/cmd.rb
+++ b/lib/between_meals/repo/hg/cmd.rb
@@ -49,6 +49,7 @@ module BetweenMeals
           f = Tempfile.new('between_meals.hg.amend')
           begin
             f.write(msg)
+            f.flush
             cmd("commit --amend -l #{f.path}")
           ensure
             f.close


### PR DESCRIPTION
File cannot be empty, otherwise hg kicks off vi interactive session in the background, which just hangs.