### PR TITLE
update error message for failing to parse a repo status line

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -80,15 +80,35 @@ FileName:
 PerceivedComplexity:
   Enabled: false
 
-TrailingComma:
-  Enabled: false
+TrailingCommaInLiteral:
+  EnforcedStyleForMultiline: comma
+
+TrailingCommaInArguments:
+  EnforcedStyleForMultiline: comma
 
 UnneededDisable:
   Enabled: false
 
-Style/Documentation:
+MultilineOperationIndentation:
   Enabled: false
 
+Performance/RedundantMatch:
+  Enabled: false
+
+Style/MutableConstant:
+  Enabled: false
+
+Performance/TimesMap:
+  Enabled: false
+
+Performance/RedundantMerge:
+  Enabled: false
+
+Style/ConditionalAssignment:
+  Enabled: false
+
+Style/IndentArray:
+  EnforcedStyle: consistent
 #
 # Modified rules
 #
@@ -100,3 +120,6 @@ DotPosition:
 
 HashSyntax:
   EnforcedStyle: hash_rockets
+
+Style/Documentation:
+  Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: ruby
 
 rvm:
-  - 1.9.3
-  - 2.0.0
+  - 2.2.2
+  - 2.3.0
 
 gemfile:
   - Gemfile

--- a/lib/between_meals/changes/cookbook.rb
+++ b/lib/between_meals/changes/cookbook.rb
@@ -38,7 +38,8 @@ module BetweenMeals
           info("Cookbook is #{m[1]}")
           return {
             :cookbook_dir => dir,
-            :name => m[1] }
+            :name => m[1],
+          }
         end
         nil
       end
@@ -47,7 +48,7 @@ module BetweenMeals
         @files = files
         @name = self.class.explode_path(
           files.sample[:path],
-          cookbook_dirs
+          cookbook_dirs,
         )[:name]
         # if metadata.rb is being deleted
         #   cookbook is marked for deletion

--- a/lib/between_meals/changeset.rb
+++ b/lib/between_meals/changeset.rb
@@ -27,7 +27,7 @@ module BetweenMeals
   # Basically, you always want to use BetweenMeals::Changes through this
   # helper class.
   class Changeset
-    class ReferenceError < Exception
+    class ReferenceError < RuntimeError
     end
 
     def initialize(logger, repo, start_ref, end_ref, locations)

--- a/lib/between_meals/cmd.rb
+++ b/lib/between_meals/cmd.rb
@@ -21,7 +21,7 @@ module BetweenMeals
     attr_accessor :bin
 
     def initialize(params)
-      @bin = params[:bin] || fail
+      @bin = params[:bin] || raise
       @cwd = params[:cwd] || Dir.pwd
       @logger = params[:logger] || Logger.new(STDOUT)
     end
@@ -34,7 +34,7 @@ module BetweenMeals
       @logger.info("Running \"#{cmd}\"")
       c = Mixlib::ShellOut.new(
         cmd,
-        :cwd => cwd
+        :cwd => cwd,
       )
       c.run_command
       c.error!

--- a/lib/between_meals/knife.rb
+++ b/lib/between_meals/knife.rb
@@ -144,7 +144,7 @@ module BetweenMeals
           end.join(' ')
           exec!(
             "#{@knife} data bag from file #{dbname} #{dbitems} -c #{@config}",
-            @logger
+            @logger,
           )
         end
       end
@@ -181,7 +181,7 @@ BLOCK
       end
       cfg << "]\n"
       unless File.directory?(File.dirname(@config))
-        Dir.mkdir(File.dirname(@config), 0755)
+        Dir.mkdir(File.dirname(@config), 0o755)
       end
       if !File.exists?(@config) ||
          ::Digest::MD5.hexdigest(cfg) !=

--- a/lib/between_meals/repo.rb
+++ b/lib/between_meals/repo.rb
@@ -70,7 +70,7 @@ module BetweenMeals
         require 'between_meals/repo/hg'
         BetweenMeals::Repo::Hg.new(repo_path, logger)
       else
-        fail "Do not know repo type #{type}"
+        raise "Do not know repo type #{type}"
       end
     end
 
@@ -80,92 +80,92 @@ module BetweenMeals
     end
 
     def exists?
-      fail "#{__method__} not implemented"
+      raise "#{__method__} not implemented"
     end
 
     def status
-      fail "#{__method__} not implemented"
+      raise "#{__method__} not implemented"
     end
 
     # This method *must* succeed in the case of no repo directory so that
     # users can call `checkout`. Users may call `exists?` to find out if
     # we have an underlying repo yet.
     def setup
-      fail "#{__method__} not implemented"
+      raise "#{__method__} not implemented"
     end
 
     def head_rev
-      fail "#{__method__} not implemented"
+      raise "#{__method__} not implemented"
     end
 
     def head_msg
-      fail "#{__method__} not implemented"
+      raise "#{__method__} not implemented"
     end
 
     def head_msg=
-      fail "#{__method__} not implemented"
+      raise "#{__method__} not implemented"
     end
 
     def head_parents
-      fail "#{__method__} not implemented"
+      raise "#{__method__} not implemented"
     end
 
     def latest_revision
-      fail "#{__method__} not implemented"
+      raise "#{__method__} not implemented"
     end
 
     def create(_url)
-      fail "#{__method__} not implemented"
+      raise "#{__method__} not implemented"
     end
 
     # Return files changed between two revisions
     def changes(_start_ref, _end_ref)
-      fail "#{__method__} not implemented"
+      raise "#{__method__} not implemented"
     end
 
     def update
-      fail "#{__method__} not implemented"
+      raise "#{__method__} not implemented"
     end
 
     # Return all files
     def files
-      fail "#{__method__} not implemented"
+      raise "#{__method__} not implemented"
     end
 
     def head
-      fail "#{__method__} not implemented"
+      raise "#{__method__} not implemented"
     end
 
     def checkout
-      fail "#{__method__} not implemented"
+      raise "#{__method__} not implemented"
     end
 
     def last_author
-      fail "#{__method__} not implemented"
+      raise "#{__method__} not implemented"
     end
 
     def last_msg
-      fail "#{__method__} not implemented"
+      raise "#{__method__} not implemented"
     end
 
     def last_msg=
-      fail "#{__method__} not implemented"
+      raise "#{__method__} not implemented"
     end
 
     def name
-      fail "#{__method__} not implemented"
+      raise "#{__method__} not implemented"
     end
 
     def email
-      fail "#{__method__} not implemented"
+      raise "#{__method__} not implemented"
     end
 
     def upstream?(_rev)
-      fail "#{__method__} not implemented"
+      raise "#{__method__} not implemented"
     end
 
     def valid_ref?(_rev)
-      fail "#{__method__} not implemented"
+      raise "#{__method__} not implemented"
     end
   end
 end

--- a/lib/between_meals/repo/git.rb
+++ b/lib/between_meals/repo/git.rb
@@ -89,7 +89,7 @@ module BetweenMeals
         rescue => e
           # We've seen some weird non-reproducible failures here
           @logger.error(
-            'Something went wrong. Please please report this output.'
+            'Something went wrong. Please report this output.'
           )
           @logger.error(e)
           stdout.lines.each do |line|
@@ -203,7 +203,7 @@ module BetweenMeals
               }
             ]
           else
-            fail 'No match'
+            fail 'Failed to parse repo status line. Try a --force-upload.'
           end
         end.flatten.map do |x|
           {

--- a/lib/between_meals/repo/git.rb
+++ b/lib/between_meals/repo/git.rb
@@ -203,7 +203,7 @@ module BetweenMeals
               }
             ]
           else
-            fail 'Failed to parse repo status line.'
+            fail 'Failed to parse repo diff line.'
           end
         end.flatten.map do |x|
           {

--- a/lib/between_meals/repo/git.rb
+++ b/lib/between_meals/repo/git.rb
@@ -203,7 +203,7 @@ module BetweenMeals
               }
             ]
           else
-            fail 'Failed to parse repo status line. Try a --force-upload.'
+            fail 'Failed to parse repo status line.'
           end
         end.flatten.map do |x|
           {

--- a/lib/between_meals/repo/git.rb
+++ b/lib/between_meals/repo/git.rb
@@ -60,7 +60,7 @@ module BetweenMeals
           {
             :message => msg,
             :update_ref => 'HEAD',
-          }
+          },
         )
       end
 
@@ -89,7 +89,7 @@ module BetweenMeals
         rescue => e
           # We've seen some weird non-reproducible failures here
           @logger.error(
-            'Something went wrong. Please report this output.'
+            'Something went wrong. Please report this output.',
           )
           @logger.error(e)
           stdout.lines.each do |line|
@@ -131,7 +131,7 @@ module BetweenMeals
 
       def valid_ref?(ref)
         unless @repo.exists?(ref)
-          fail Changeset::ReferenceError
+          raise Changeset::ReferenceError
         end
       end
 
@@ -158,57 +158,57 @@ module BetweenMeals
             # A path
             {
               :status => :modified,
-              :path => Regexp.last_match(1)
+              :path => Regexp.last_match(1),
             }
           when /^C(?:\d*)\s+(\S+)\s+(\S+)/
             # C<numbers> path1 path2
             {
               :status => :modified,
-              :path => Regexp.last_match(2)
+              :path => Regexp.last_match(2),
             }
           when /^D\s+(\S+)$/
             # D path
             {
               :status => :deleted,
-              :path => Regexp.last_match(1)
+              :path => Regexp.last_match(1),
             }
           when /^M(?:\d*)\s+(\S+)$/
             # M<numbers> path
             {
               :status => :modified,
-              :path => Regexp.last_match(1)
+              :path => Regexp.last_match(1),
             }
           when /^R(?:\d*)\s+(\S+)\s+(\S+)/
             # R<numbers> path1 path2
             [
               {
                 :status => :deleted,
-                :path => Regexp.last_match(1)
+                :path => Regexp.last_match(1),
               },
               {
                 :status => :modified,
-                :path => Regexp.last_match(2)
-              }
+                :path => Regexp.last_match(2),
+              },
             ]
           when /^T\s+(\S+)$/
             # T path
             [
               {
                 :status => :deleted,
-                :path => Regexp.last_match(1)
+                :path => Regexp.last_match(1),
               },
               {
                 :status => :modified,
-                :path => Regexp.last_match(1)
-              }
+                :path => Regexp.last_match(1),
+              },
             ]
           else
-            fail 'Failed to parse repo diff line.'
+            raise 'Failed to parse repo diff line.'
           end
         end.flatten.map do |x|
           {
             :status => x[:status],
-            :path => x[:path].sub("#{@repo_path}/", '')
+            :path => x[:path].sub("#{@repo_path}/", ''),
           }
         end
         # rubocop:enable MultilineBlockChain

--- a/lib/between_meals/repo/hg.rb
+++ b/lib/between_meals/repo/hg.rb
@@ -204,7 +204,7 @@ module BetweenMeals
               :path => Regexp.last_match(1)
             }
           else
-            fail 'Failed to parse repo status line.'
+            fail 'Failed to parse repo diff line.'
           end
         end
         # rubocop:enable MultilineBlockChain

--- a/lib/between_meals/repo/hg.rb
+++ b/lib/between_meals/repo/hg.rb
@@ -53,7 +53,7 @@ module BetweenMeals
         rescue => e
           # We've seen some weird non-reproducible failures here
           @logger.error(
-            'Something went wrong. Please report this output.'
+            'Something went wrong. Please report this output.',
           )
           @logger.error(e)
           stdout.lines.each do |line|
@@ -171,40 +171,40 @@ module BetweenMeals
           when /^A (\S+)$/
             {
               :status => :added,
-              :path => Regexp.last_match(1)
+              :path => Regexp.last_match(1),
             }
           when /^C (\S+)$/
             {
               :status => :clean,
-              :path => Regexp.last_match(1)
+              :path => Regexp.last_match(1),
             }
           when /^R (\S+)$/
             {
               :status => :deleted,
-              :path => Regexp.last_match(1)
+              :path => Regexp.last_match(1),
             }
           when /^M (\S+)$/
             {
               :status => :modified,
-              :path => Regexp.last_match(1)
+              :path => Regexp.last_match(1),
             }
           when /^! (\S+)$/
             {
               :status => :missing,
-              :path => Regexp.last_match(1)
+              :path => Regexp.last_match(1),
             }
           when /^\? (\S+)$/
             {
               :status => :untracked,
-              :path => Regexp.last_match(1)
+              :path => Regexp.last_match(1),
             }
           when /^I (\S+)$/
             {
               :status => :ignored,
-              :path => Regexp.last_match(1)
+              :path => Regexp.last_match(1),
             }
           else
-            fail 'Failed to parse repo diff line.'
+            raise 'Failed to parse repo diff line.'
           end
         end
         # rubocop:enable MultilineBlockChain

--- a/lib/between_meals/repo/hg.rb
+++ b/lib/between_meals/repo/hg.rb
@@ -204,7 +204,7 @@ module BetweenMeals
               :path => Regexp.last_match(1)
             }
           else
-            fail 'Failed to parse repo status line. Try a --force-upload.'
+            fail 'Failed to parse repo status line.'
           end
         end
         # rubocop:enable MultilineBlockChain

--- a/lib/between_meals/repo/hg.rb
+++ b/lib/between_meals/repo/hg.rb
@@ -53,7 +53,7 @@ module BetweenMeals
         rescue => e
           # We've seen some weird non-reproducible failures here
           @logger.error(
-            'Something went wrong. Please please report this output.'
+            'Something went wrong. Please report this output.'
           )
           @logger.error(e)
           stdout.lines.each do |line|
@@ -204,7 +204,7 @@ module BetweenMeals
               :path => Regexp.last_match(1)
             }
           else
-            fail 'No match'
+            fail 'Failed to parse repo status line. Try a --force-upload.'
           end
         end
         # rubocop:enable MultilineBlockChain

--- a/lib/between_meals/repo/svn.rb
+++ b/lib/between_meals/repo/svn.rb
@@ -109,7 +109,7 @@ module BetweenMeals
               :path => Regexp.last_match(2).sub("#{@repo_path}/", ''),
             }
           else
-            fail 'Failed to parse repo status line. Try a --force-upload.'
+            fail 'Failed to parse repo status line.'
           end
         end
       end

--- a/lib/between_meals/repo/svn.rb
+++ b/lib/between_meals/repo/svn.rb
@@ -109,7 +109,7 @@ module BetweenMeals
               :path => Regexp.last_match(2).sub("#{@repo_path}/", ''),
             }
           else
-            fail 'Failed to parse repo status line.'
+            fail 'Failed to parse repo diff line.'
           end
         end
       end

--- a/lib/between_meals/repo/svn.rb
+++ b/lib/between_meals/repo/svn.rb
@@ -66,7 +66,7 @@ module BetweenMeals
           parse_status(changes).compact
         rescue => e
           @logger.error(
-            'Something went wrong. Please please report this output.'
+            'Something went wrong. Please report this output.'
           )
           @logger.error(e)
           stdout.lines.each do |line|
@@ -109,7 +109,7 @@ module BetweenMeals
               :path => Regexp.last_match(2).sub("#{@repo_path}/", ''),
             }
           else
-            fail 'No match'
+            fail 'Failed to parse repo status line. Try a --force-upload.'
           end
         end
       end

--- a/lib/between_meals/repo/svn.rb
+++ b/lib/between_meals/repo/svn.rb
@@ -66,7 +66,7 @@ module BetweenMeals
           parse_status(changes).compact
         rescue => e
           @logger.error(
-            'Something went wrong. Please report this output.'
+            'Something went wrong. Please report this output.',
           )
           @logger.error(e)
           stdout.lines.each do |line|
@@ -103,13 +103,13 @@ module BetweenMeals
         # http://svnbook.red-bean.com/en/1.0/re26.html
         changes.lines.map do |line|
           case line
-          when (/^([\w ])\w?\s+(\S+)$/)
+          when /^([\w ])\w?\s+(\S+)$/
             {
               :status => Regexp.last_match(1) == 'D' ? :deleted : :modified,
               :path => Regexp.last_match(2).sub("#{@repo_path}/", ''),
             }
           else
-            fail 'Failed to parse repo diff line.'
+            raise 'Failed to parse repo diff line.'
           end
         end
       end

--- a/spec/cookbook_spec.rb
+++ b/spec/cookbook_spec.rb
@@ -39,11 +39,11 @@ describe BetweenMeals::Changes::Cookbook do
       :files => [
         {
           :status => :modified,
-          :path => 'cookbooks/two/cb_one/recipes/test.rb'
+          :path => 'cookbooks/two/cb_one/recipes/test.rb',
         },
         {
           :status => :modified,
-          :path => 'cookbooks/two/cb_one/metadata.rb'
+          :path => 'cookbooks/two/cb_one/metadata.rb',
         },
       ],
       :result => [
@@ -55,15 +55,15 @@ describe BetweenMeals::Changes::Cookbook do
       :files => [
         {
           :status => :modified,
-          :path => 'cookbooks/one/cb_one/recipes/test.rb'
+          :path => 'cookbooks/one/cb_one/recipes/test.rb',
         },
         {
           :status => :deleted,
-          :path => 'cookbooks/one/cb_one/recipes/test2.rb'
+          :path => 'cookbooks/one/cb_one/recipes/test2.rb',
         },
         {
           :status => :modified,
-          :path => 'cookbooks/one/cb_one/recipes/test3.rb'
+          :path => 'cookbooks/one/cb_one/recipes/test3.rb',
         },
       ],
       :result => [
@@ -75,11 +75,11 @@ describe BetweenMeals::Changes::Cookbook do
       :files => [
         {
           :status => :modified,
-          :path => 'cookbooks/one/cb_one/recipes/test.rb'
+          :path => 'cookbooks/one/cb_one/recipes/test.rb',
         },
         {
           :status => :deleted,
-          :path => 'cookbooks/one/cb_one/metadata.rb'
+          :path => 'cookbooks/one/cb_one/metadata.rb',
         },
       ],
       :result => [
@@ -91,23 +91,23 @@ describe BetweenMeals::Changes::Cookbook do
       :files => [
         {
           :status => :deleted,
-          :path => 'cookbooks/one/cb_one/recipes/test.rb'
+          :path => 'cookbooks/one/cb_one/recipes/test.rb',
         },
         {
           :status => :deleted,
-          :path => 'cookbooks/one/cb_one/metadata.rb'
+          :path => 'cookbooks/one/cb_one/metadata.rb',
         },
         {
           :status => :modified,
-          :path => 'cookbooks/two/cb_one/recipes/test.rb'
+          :path => 'cookbooks/two/cb_one/recipes/test.rb',
         },
         {
           :status => :modified,
-          :path => 'cookbooks/two/cb_one/recipes/test2.rb'
+          :path => 'cookbooks/two/cb_one/recipes/test2.rb',
         },
         {
           :status => :modified,
-          :path => 'cookbooks/two/cb_one/metadata.rb'
+          :path => 'cookbooks/two/cb_one/metadata.rb',
         },
       ],
       :result => [
@@ -120,7 +120,7 @@ describe BetweenMeals::Changes::Cookbook do
       :files => [
         {
           :status => :modified,
-          :path => 'cookbooks/two/cb_one/metadata.rb'
+          :path => 'cookbooks/two/cb_one/metadata.rb',
         },
       ],
       :result => [
@@ -132,7 +132,7 @@ describe BetweenMeals::Changes::Cookbook do
       :files => [
         {
           :status => :modified,
-          :path => 'cookbooks/two/cb_one/README.md'
+          :path => 'cookbooks/two/cb_one/README.md',
         },
       ],
       :result => [
@@ -144,7 +144,7 @@ describe BetweenMeals::Changes::Cookbook do
       :files => [
         {
           :status => :modified,
-          :path => 'cookbooks/two/cb_one/recipe/default.rb'
+          :path => 'cookbooks/two/cb_one/recipe/default.rb',
         },
       ],
       :result => [
@@ -156,15 +156,15 @@ describe BetweenMeals::Changes::Cookbook do
       :files => [
         {
           :status => :modified,
-          :path => 'cookbooks/two/OWNERS'
+          :path => 'cookbooks/two/OWNERS',
         },
         {
           :status => :modified,
-          :path => 'cookbooks/OWNERS'
+          :path => 'cookbooks/OWNERS',
         },
         {
           :status => :modified,
-          :path => 'OWNERS'
+          :path => 'OWNERS',
         },
       ],
       :result => [
@@ -177,7 +177,7 @@ describe BetweenMeals::Changes::Cookbook do
       BetweenMeals::Changes::Cookbook.find(
         fixture[:files],
         cookbook_dirs,
-        logger
+        logger,
       ).map do |cb|
         [cb.name, cb.status]
       end.

--- a/spec/databag_spec.rb
+++ b/spec/databag_spec.rb
@@ -38,15 +38,15 @@ describe BetweenMeals::Changes::Databag do
       :files => [
         {
           :status => :deleted,
-          :path => 'databags/test/databag1.json'
+          :path => 'databags/test/databag1.json',
         },
         {
           :status => :deleted,
-          :path => 'databags/test1/test2/databag2.json'
+          :path => 'databags/test1/test2/databag2.json',
         },
         {
           :status => :modified,
-          :path => 'cookbooks/two/cb_one/metadata.rb'
+          :path => 'cookbooks/two/cb_one/metadata.rb',
         },
       ],
       :result => [
@@ -58,7 +58,7 @@ describe BetweenMeals::Changes::Databag do
       :files => [
         {
           :status => :modified,
-          :path => 'databags/one/databag1.json'
+          :path => 'databags/one/databag1.json',
         },
         {
           :status => :deleted,
@@ -66,7 +66,7 @@ describe BetweenMeals::Changes::Databag do
         },
         {
           :status => :deleted,
-          :path => 'databags/two/databag3.json'
+          :path => 'databags/two/databag3.json',
         },
       ],
       :result => [
@@ -80,7 +80,7 @@ describe BetweenMeals::Changes::Databag do
       BetweenMeals::Changes::Databag.find(
         fixture[:files],
         roles_dir,
-        logger
+        logger,
       ).map do |cb|
         [cb.name, cb.status]
       end.

--- a/spec/git_spec.rb
+++ b/spec/git_spec.rb
@@ -28,7 +28,7 @@ describe BetweenMeals::Repo::Git do
     {
       :name => 'empty filelists',
       :changes => '',
-      :result => []
+      :result => [],
     },
     {
       :name => 'handle renames',

--- a/spec/git_spec.rb
+++ b/spec/git_spec.rb
@@ -91,6 +91,7 @@ EOS
         should eq(fixture[:result])
     end
   end
+
   it 'should error on spaces in file names' do
     BetweenMeals::Repo::Git.any_instance.stub(:setup).and_return(true)
     git = BetweenMeals::Repo::Git.new('foo', logger)
@@ -98,6 +99,7 @@ EOS
       git.send(:parse_status, 'M foo/bar baz')
     end.should raise_error('Failed to parse repo status line. Try a --force-upload.')
   end
+
   it 'should handle malformed output' do
     BetweenMeals::Repo::Git.any_instance.stub(:setup).and_return(true)
     git = BetweenMeals::Repo::Git.new('foo', logger)

--- a/spec/git_spec.rb
+++ b/spec/git_spec.rb
@@ -97,7 +97,7 @@ EOS
     git = BetweenMeals::Repo::Git.new('foo', logger)
     lambda do
       git.send(:parse_status, 'M foo/bar baz')
-    end.should raise_error('Failed to parse repo status line.')
+    end.should raise_error('Failed to parse repo diff line.')
   end
 
   it 'should handle malformed output' do
@@ -105,6 +105,6 @@ EOS
     git = BetweenMeals::Repo::Git.new('foo', logger)
     lambda do
       git.send(:parse_status, 'HGFS djs/ dsd)')
-    end.should raise_error('Failed to parse repo status line.')
+    end.should raise_error('Failed to parse repo diff line.')
   end
 end

--- a/spec/git_spec.rb
+++ b/spec/git_spec.rb
@@ -91,6 +91,13 @@ EOS
         should eq(fixture[:result])
     end
   end
+  it 'should error on spaces in file names' do
+    BetweenMeals::Repo::Git.any_instance.stub(:setup).and_return(true)
+    git = BetweenMeals::Repo::Git.new('foo', logger)
+    lambda do
+      git.send(:parse_status, 'M foo/bar baz')
+    end.should raise_error('Failed to parse repo status line. Try a --force-upload.')
+  end
   it 'should handle malformed output' do
     BetweenMeals::Repo::Git.any_instance.stub(:setup).and_return(true)
     git = BetweenMeals::Repo::Git.new('foo', logger)

--- a/spec/git_spec.rb
+++ b/spec/git_spec.rb
@@ -97,7 +97,7 @@ EOS
     git = BetweenMeals::Repo::Git.new('foo', logger)
     lambda do
       git.send(:parse_status, 'M foo/bar baz')
-    end.should raise_error('Failed to parse repo status line. Try a --force-upload.')
+    end.should raise_error('Failed to parse repo status line.')
   end
 
   it 'should handle malformed output' do
@@ -105,6 +105,6 @@ EOS
     git = BetweenMeals::Repo::Git.new('foo', logger)
     lambda do
       git.send(:parse_status, 'HGFS djs/ dsd)')
-    end.should raise_error('No match')
+    end.should raise_error('Failed to parse repo status line.')
   end
 end

--- a/spec/hg_spec.rb
+++ b/spec/hg_spec.rb
@@ -119,4 +119,20 @@ describe BetweenMeals::Repo::Hg do
       hg.name.should eq(example[:name])
     end
   end
+
+  it 'should error on spaces in file names' do
+    BetweenMeals::Repo::Hg.any_instance.stub(:setup).and_return(true)
+    svn = BetweenMeals::Repo::Hg.new('foo', logger)
+    lambda do
+      svn.send(:parse_status, 'M foo/bar baz')
+    end.should raise_error('Failed to parse repo status line. Try a --force-upload.')
+  end
+
+  it 'should handle malformed output' do
+    BetweenMeals::Repo::Hg.any_instance.stub(:setup).and_return(true)
+    svn = BetweenMeals::Repo::Hg.new('foo', logger)
+    lambda do
+      svn.send(:parse_status, 'HGFS djs/ dsd)')
+    end.should raise_error('No match')
+  end
 end

--- a/spec/hg_spec.rb
+++ b/spec/hg_spec.rb
@@ -125,7 +125,7 @@ describe BetweenMeals::Repo::Hg do
     svn = BetweenMeals::Repo::Hg.new('foo', logger)
     lambda do
       svn.send(:parse_status, 'M foo/bar baz')
-    end.should raise_error('Failed to parse repo status line.')
+    end.should raise_error('Failed to parse repo diff line.')
   end
 
   it 'should handle malformed output' do
@@ -133,6 +133,6 @@ describe BetweenMeals::Repo::Hg do
     svn = BetweenMeals::Repo::Hg.new('foo', logger)
     lambda do
       svn.send(:parse_status, 'HGFS djs/ dsd)')
-    end.should raise_error('Failed to parse repo status line.')
+    end.should raise_error('Failed to parse repo diff line.')
   end
 end

--- a/spec/hg_spec.rb
+++ b/spec/hg_spec.rb
@@ -28,7 +28,7 @@ describe BetweenMeals::Repo::Hg do
     {
       :name => 'empty filelists',
       :changes => '',
-      :result => []
+      :result => [],
     },
     {
       :name => 'handle additions',

--- a/spec/hg_spec.rb
+++ b/spec/hg_spec.rb
@@ -125,7 +125,7 @@ describe BetweenMeals::Repo::Hg do
     svn = BetweenMeals::Repo::Hg.new('foo', logger)
     lambda do
       svn.send(:parse_status, 'M foo/bar baz')
-    end.should raise_error('Failed to parse repo status line. Try a --force-upload.')
+    end.should raise_error('Failed to parse repo status line.')
   end
 
   it 'should handle malformed output' do
@@ -133,6 +133,6 @@ describe BetweenMeals::Repo::Hg do
     svn = BetweenMeals::Repo::Hg.new('foo', logger)
     lambda do
       svn.send(:parse_status, 'HGFS djs/ dsd)')
-    end.should raise_error('No match')
+    end.should raise_error('Failed to parse repo status line.')
   end
 end

--- a/spec/role_spec.rb
+++ b/spec/role_spec.rb
@@ -38,11 +38,11 @@ describe BetweenMeals::Changes::Role do
       :files => [
         {
           :status => :deleted,
-          :path => 'roles/test.rb'
+          :path => 'roles/test.rb',
         },
         {
           :status => :modified,
-          :path => 'cookbooks/two/cb_one/metadata.rb'
+          :path => 'cookbooks/two/cb_one/metadata.rb',
         },
       ],
       :result => [
@@ -54,15 +54,15 @@ describe BetweenMeals::Changes::Role do
       :files => [
         {
           :status => :modified,
-          :path => 'cookbooks/one/cb_one/recipes/test.rb'
+          :path => 'cookbooks/one/cb_one/recipes/test.rb',
         },
         {
           :status => :modified,
-          :path => 'roles/test.rb'
+          :path => 'roles/test.rb',
         },
         {
           :status => :modified,
-          :path => 'cookbooks/one/cb_one/recipes/test3.rb'
+          :path => 'cookbooks/one/cb_one/recipes/test3.rb',
         },
       ],
       :result => [
@@ -76,7 +76,7 @@ describe BetweenMeals::Changes::Role do
       BetweenMeals::Changes::Role.find(
         fixture[:files],
         roles_dir,
-        logger
+        logger,
       ).map do |cb|
         [cb.name, cb.status]
       end.

--- a/spec/svn_spec.rb
+++ b/spec/svn_spec.rb
@@ -77,6 +77,13 @@ describe BetweenMeals::Repo::Svn do
         should eq(fixture[:result])
     end
   end
+  it 'should error on spaces in file names' do
+    BetweenMeals::Repo::Svn.any_instance.stub(:setup).and_return(true)
+    svn = BetweenMeals::Repo::Svn.new('foo', logger)
+    lambda do
+      svn.send(:parse_status, 'M foo/bar baz')
+    end.should raise_error('Failed to parse repo status line. Try a --force-upload.')
+  end
   it 'should handle malformed output' do
     BetweenMeals::Repo::Svn.any_instance.stub(:setup).and_return(true)
     svn = BetweenMeals::Repo::Svn.new('foo', logger)

--- a/spec/svn_spec.rb
+++ b/spec/svn_spec.rb
@@ -77,6 +77,7 @@ describe BetweenMeals::Repo::Svn do
         should eq(fixture[:result])
     end
   end
+
   it 'should error on spaces in file names' do
     BetweenMeals::Repo::Svn.any_instance.stub(:setup).and_return(true)
     svn = BetweenMeals::Repo::Svn.new('foo', logger)
@@ -84,6 +85,7 @@ describe BetweenMeals::Repo::Svn do
       svn.send(:parse_status, 'M foo/bar baz')
     end.should raise_error('Failed to parse repo status line. Try a --force-upload.')
   end
+
   it 'should handle malformed output' do
     BetweenMeals::Repo::Svn.any_instance.stub(:setup).and_return(true)
     svn = BetweenMeals::Repo::Svn.new('foo', logger)

--- a/spec/svn_spec.rb
+++ b/spec/svn_spec.rb
@@ -83,7 +83,7 @@ describe BetweenMeals::Repo::Svn do
     svn = BetweenMeals::Repo::Svn.new('foo', logger)
     lambda do
       svn.send(:parse_status, 'M foo/bar baz')
-    end.should raise_error('Failed to parse repo status line.')
+    end.should raise_error('Failed to parse repo diff line.')
   end
 
   it 'should handle malformed output' do
@@ -91,6 +91,6 @@ describe BetweenMeals::Repo::Svn do
     svn = BetweenMeals::Repo::Svn.new('foo', logger)
     lambda do
       svn.send(:parse_status, 'HGFS djs/ dsd)')
-    end.should raise_error('Failed to parse repo status line.')
+    end.should raise_error('Failed to parse repo diff line.')
   end
 end

--- a/spec/svn_spec.rb
+++ b/spec/svn_spec.rb
@@ -83,7 +83,7 @@ describe BetweenMeals::Repo::Svn do
     svn = BetweenMeals::Repo::Svn.new('foo', logger)
     lambda do
       svn.send(:parse_status, 'M foo/bar baz')
-    end.should raise_error('Failed to parse repo status line. Try a --force-upload.')
+    end.should raise_error('Failed to parse repo status line.')
   end
 
   it 'should handle malformed output' do
@@ -91,6 +91,6 @@ describe BetweenMeals::Repo::Svn do
     svn = BetweenMeals::Repo::Svn.new('foo', logger)
     lambda do
       svn.send(:parse_status, 'HGFS djs/ dsd)')
-    end.should raise_error('No match')
+    end.should raise_error('Failed to parse repo status line.')
   end
 end


### PR DESCRIPTION
If we have malformed input (such as a space in a filename that can't be
handled), between-meals currently prints 'No match'. This error message
is not useful. Update the message and the specs.