### PR TITLE
Fix cookbook matching if cookbook_dirs include subfolders

### DIFF
--- a/lib/between_meals/changes/cookbook.rb
+++ b/lib/between_meals/changes/cookbook.rb
@@ -30,7 +30,7 @@ module BetweenMeals
       end
 
       def self.explode_path(path, cookbook_dirs)
-        cookbook_dirs.each do |dir|
+        cookbook_dirs.sort_by{ |a| a.length }.reverse.each do |dir|
           re = %r{^#{dir}/([^/]+)/.*}
           debug("[cookbook] Matching #{path} against ^#{re}")
           m = path.match(re)

--- a/spec/cookbook_spec.rb
+++ b/spec/cookbook_spec.rb
@@ -170,13 +170,26 @@ describe BetweenMeals::Changes::Cookbook do
       :result => [
       ],
     },
+    {
+      :name => 'match deepest subfolder first',
+      :files => [
+        {
+          :status => :modified,
+          :path => 'cookbooks/core/cb_one/metadata.rb',
+        },
+      ],
+      :cookbook_dirs => ['cookbooks', 'cookbooks/core'],
+      :result => [
+        ['cb_one', :modified],
+      ],
+    },
   ]
 
   fixtures.each do |fixture|
     it "should handle #{fixture[:name]}" do
       BetweenMeals::Changes::Cookbook.find(
         fixture[:files],
-        cookbook_dirs,
+        fixture[:cookbook_dirs] || cookbook_dirs,
         logger,
       ).map do |cb|
         [cb.name, cb.status]


### PR DESCRIPTION
When cookbook_dirs list includes nested folders (i.e. ['cookbooks', 'cookbooks/core']) cookbook name should be matched against deepest subfolder e.i. longer path first.
Now result is dependent on order of items in cookbook_dirs list and can return subfolder name as a cookbook name.