### PR TITLE
Fix ci build systems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: ruby
 
+before_install: gem update --system
+
 rvm:
   - 2.2.2
   - 2.3.0

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
 source 'https://rubygems.org'
 
 gemspec
+
+gem 'rake' # See: sickill/rainbow#44

--- a/circle.yml
+++ b/circle.yml
@@ -3,5 +3,8 @@ machine:
     version: 2.3.0
 
 test:
+  pre:
+    - gem update --system
   post:
     - bundle exec rspec
+    - bundle exec rubocop --display-cop-names

--- a/lib/between_meals/repo/svn.rb
+++ b/lib/between_meals/repo/svn.rb
@@ -88,8 +88,7 @@ module BetweenMeals
         end
       end
 
-      def upstream?
-      end
+      def upstream?; end
 
       def valid_ref?(ref)
         @cmd.info_r(ref, @repo_path)


### PR DESCRIPTION
Rubgems < 2.6.9 prevents the rainbow gem from being installed.
See: sickill/rainbow#44
Partial fix for: facebook/between-meals#64