### PR TITLE
Add /usr/local/bin to command path so macOS can find binaries correctly

### DIFF
--- a/lib/between_meals/cmd.rb
+++ b/lib/between_meals/cmd.rb
@@ -36,6 +36,10 @@ module BetweenMeals
         cmd,
         :cwd => cwd,
       )
+      # macOS needs /usr/local/bin as hg cannot be installed in /bin or /usr/bin
+      c.environment = {
+        'PATH' => '/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/bin',
+      }
       c.run_command
       c.error!
       c


### PR DESCRIPTION
On macOS, one cannot install binaries to /bin or /usr/bin as they are locked down with SIP. hg is installed into /usr/local/bin, so without tweaking the PATH, this does not work on macOS.

I'm not sure if this is the best way to shim the path in, so suggestions are welcome ;) 