### PR TITLE
Create pem dir if it does not already exist

### DIFF
--- a/lib/between_meals/changes/change.rb
+++ b/lib/between_meals/changes/change.rb
@@ -58,3 +58,4 @@ module BetweenMeals
     end
   end
 end
+# rubocop:enable ClassVars

--- a/lib/between_meals/changes/cookbook.rb
+++ b/lib/between_meals/changes/cookbook.rb
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# rubocop:disable ClassVars
 module BetweenMeals
   module Changes
     # Changeset aware cookbook
@@ -106,7 +105,9 @@ module BetweenMeals
       # Given a list of changed files
       # create a list of Cookbook objects
       def self.find(list, cookbook_dirs, logger, repo, track_symlinks = false)
+        # rubocop:disable ClassVars
         @@logger = logger
+        # rubocop:enable ClassVars
         return [] if list.nil? || list.empty?
         # rubocop:disable MultilineBlockChain
         @repo_dir = File.realpath(repo.repo_path)

--- a/lib/between_meals/changes/databag.rb
+++ b/lib/between_meals/changes/databag.rb
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# rubocop:disable ClassVars
 module BetweenMeals
   module Changes
     # Changeset aware databag
@@ -37,7 +36,9 @@ module BetweenMeals
       end
 
       def self.find(list, databag_dir, logger)
+        # rubocop:disable ClassVars
         @@logger = logger
+        # rubocop:enable ClassVars
         return [] if list.nil? || list.empty?
         list.
           select { |x| self.name_from_path(x[:path], databag_dir) }.

--- a/lib/between_meals/changes/role.rb
+++ b/lib/between_meals/changes/role.rb
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# rubocop:disable ClassVars
 module BetweenMeals
   module Changes
     # Changeset aware role
@@ -38,7 +37,9 @@ module BetweenMeals
       # Given a list of changed files
       # create a list of Role objects
       def self.find(list, role_dir, logger)
+        # rubocop:disable ClassVars
         @@logger = logger
+        # rubocop:enable ClassVars
         return [] if list.nil? || list.empty?
         list.
           select { |x| self.name_from_path(x[:path], role_dir) }.

--- a/lib/between_meals/changeset.rb
+++ b/lib/between_meals/changeset.rb
@@ -33,7 +33,7 @@ module BetweenMeals
     def initialize(
       logger, repo, start_ref, end_ref, locations, track_symlinks = false
     )
-    # rubocop:enable Metrics/ParameterLists
+      # rubocop:enable Metrics/ParameterLists
       @logger = logger
       @repo = repo
       @cookbook_dirs = locations[:cookbook_dirs].dup

--- a/lib/between_meals/changeset.rb
+++ b/lib/between_meals/changeset.rb
@@ -33,6 +33,7 @@ module BetweenMeals
     def initialize(
       logger, repo, start_ref, end_ref, locations, track_symlinks = false
     )
+    # rubocop:enable Metrics/ParameterLists
       @logger = logger
       @repo = repo
       @cookbook_dirs = locations[:cookbook_dirs].dup

--- a/lib/between_meals/knife.rb
+++ b/lib/between_meals/knife.rb
@@ -227,6 +227,10 @@ IAMAEpsWX2s2A6phgMCx7kH6wMmoZn3hb7Thh9+PfR8Jtp2/7k+ibCeF4gEWUCs5
 -----END PRIVATE KEY-----
     BLOCK
 
+      unless File.directory?(File.dirname(@pem))
+        Dir.mkdir(File.dirname(@pem), 0o755)
+      end
+
       unless File.exists?(@pem)
         @logger.info("Generating #{@pem}")
         File.write(@pem, pem)

--- a/lib/between_meals/util.rb
+++ b/lib/between_meals/util.rb
@@ -86,3 +86,4 @@ module BetweenMeals
     end
   end
 end
+# rubocop:enable ClassVars


### PR DESCRIPTION
We're currently running into an issue where users are getting a 'No such file
or directory' error when knife tries to write a new pem in the default
dir. This is happening because the config dir != the pem dir, meaning only the config
dir is automatically created.