### PR TITLE
Remove explicit dependency on 'json' rubygem

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -131,7 +131,10 @@ HashSyntax:
 Style/Documentation:
   Enabled: false
 
-TrailingCommaInLiteral:
+TrailingCommaInArrayLiteral:
+  EnforcedStyleForMultiline: comma
+
+TrailingCommaInHashLiteral:
   EnforcedStyleForMultiline: comma
 
 TrailingCommaInArguments:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -87,9 +87,6 @@ FileName:
 PerceivedComplexity:
   Enabled: false
 
-UnneededDisable:
-  Enabled: false
-
 # Seems buggy - https://github.com/bbatsov/rubocop/issues/2690
 MultilineOperationIndentation:
   Enabled: false
@@ -106,11 +103,7 @@ Performance/TimesMap:
 Performance/RedundantMerge:
   Enabled: false
 
-# Bug with constants? https://phabricator.fb.com/P56108678
-Style/ConditionalAssignment:
-  Enabled: false
-
-Style/IndentHeredoc:
+Layout/IndentHeredoc:
   Enabled: false
 
 Naming/HeredocDelimiterNaming:
@@ -140,7 +133,7 @@ TrailingCommaInHashLiteral:
 TrailingCommaInArguments:
   EnforcedStyleForMultiline: comma
 
-Style/IndentArray:
+Layout/IndentArray:
   EnforcedStyle: consistent
 
 Style/SignalException:
@@ -149,7 +142,7 @@ Style/SignalException:
 Style/NumericLiteralPrefix:
   Enabled: false
 
-Style/VariableNumber:
+Naming/VariableNumber:
   Enabled: false
 
 Metrics/BlockLength:

--- a/between_meals.gemspec
+++ b/between_meals.gemspec
@@ -12,7 +12,6 @@ Gem::Specification.new do |s|
   s.license = 'Apache'
   %w{
     colorize
-    json
     mixlib-shellout
     rugged
   }.each do |dep|

--- a/lib/between_meals/repo/hg.rb
+++ b/lib/between_meals/repo/hg.rb
@@ -165,7 +165,6 @@ module BetweenMeals
         #  I = ignored
         #    = origin of the previous file (with --copies)
 
-        # rubocop:disable MultilineBlockChain
         changes.lines.map do |line|
           case line
           when /^A (\S+)$/
@@ -207,7 +206,6 @@ module BetweenMeals
             fail 'Failed to parse repo diff line.'
           end
         end
-        # rubocop:enable MultilineBlockChain
       end
     end
   end


### PR DESCRIPTION
All modern ruby runtimes already include an implementation