### PR TITLE
Fix message amend on hg

### DIFF
--- a/lib/between_meals/repo/hg/cmd.rb
+++ b/lib/between_meals/repo/hg/cmd.rb
@@ -50,7 +50,7 @@ module BetweenMeals
           begin
             f.write(msg)
             f.flush
-            cmd("commit --amend -l #{f.path}")
+            cmd("commit --amend --exclude '**' -l #{f.path}")
           ensure
             f.close
             f.unlink


### PR DESCRIPTION
The amend function is supposed to amend only the message not changes in the
repo. This seems to be the only way to do it in stock mercurial.