### PR TITLE
handle multiple MD files

### DIFF
--- a/lib/between_meals/changes/cookbook.rb
+++ b/lib/between_meals/changes/cookbook.rb
@@ -83,7 +83,8 @@ module BetweenMeals
         @files = files
         @cookbook_dirs = cookbook_dirs
         @name = self.class.explode_path(files.sample[:path])[:name]
-        # if metadata.rb is being deleted
+        # if metadata.(json|rb) is being deleted and we aren't also
+        # adding/modifying one of those two,
         #   cookbook is marked for deletion
         # otherwise it was modified
         #   and will be re-uploaded
@@ -95,7 +96,13 @@ module BetweenMeals
              )
            end.
            compact.
-           any?
+           any? &&
+           files.reject { |x| x[:status] == :deleted }.
+           map do |x|
+             x[:path].match(
+               %{^(#{cookbook_dirs.join('|')})/[^/]+/metadata\.(rb|json)$},
+             )
+           end.none?
           @status = :deleted
         else
           @status = :modified

--- a/spec/cookbook_spec.rb
+++ b/spec/cookbook_spec.rb
@@ -180,6 +180,38 @@ describe BetweenMeals::Changes::Cookbook do
       :result => [],
     },
     {
+      :name => 'one metadata deleted, one modified',
+      :files => [
+        {
+          :status => :deleted,
+          :path => 'cookbooks/one/cb_one/metadata.json',
+        },
+        {
+          :status => :modified,
+          :path => 'cookbooks/one/cb_one/metadata.rb',
+        },
+      ],
+      :result => [
+        ['cb_one', :modified],
+      ],
+    },
+    {
+      :name => 'deleting both metadata files',
+      :files => [
+        {
+          :status => :deleted,
+          :path => 'cookbooks/one/cb_one/metadata.json',
+        },
+        {
+          :status => :deleted,
+          :path => 'cookbooks/one/cb_one/metadata.rb',
+        },
+      ],
+      :result => [
+        ['cb_one', :deleted],
+      ],
+    },
+    {
       :name => 'when metadata file is not in the root of the cb dir',
       :files => [
         {


### PR DESCRIPTION
If you end up deleting `metadata.json` while keeping `metadata.rb`, BM will
still treat this as deleting a cookbook. This PR provides and out: as long as
you are adding or modifying `metadata.rb`, you can delete `metadata.json`, or
vise-versa.

Signed-off-by: Phil Dibowitz <phil@ipom.com>