### PR TITLE
Check all host IP addresses in port_open?

### DIFF
--- a/lib/between_meals/util.rb
+++ b/lib/between_meals/util.rb
@@ -69,18 +69,23 @@ module BetweenMeals
     end
 
     def port_open?(port)
-      begin
-        Timeout.timeout(1) do
-          begin
-            s = TCPSocket.new('localhost', port)
-            s.close
-            return true
-          rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH
-            return false
+      ips = Socket.ip_address_list
+      ips.map! { |ip| ip.ip_address }
+      ips.unshift('localhost')
+      ips.each do |ip|
+        begin
+          Timeout.timeout(1) do
+            begin
+              s = TCPSocket.new(ip, port)
+              s.close
+              return true
+            rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH
+              next
+            end
           end
+        rescue Timeout::Error
+          next
         end
-      rescue Timeout::Error
-        return false
       end
       return false
     end


### PR DESCRIPTION
While testing chef_port_range for itchef, I noticed that port_open? was
incorrectly returning false. This was because we're currently only
checking whether 'localhost' is open, but not other IP addresses on a
host. Because taste-tester listens on '::', the check should be done for
each IP prior to returning a result.