### PR TITLE
Added new helper for testing whether chef-zero is running

### DIFF
--- a/lib/between_meals/changes/cookbook.rb
+++ b/lib/between_meals/changes/cookbook.rb
@@ -30,6 +30,7 @@ module BetweenMeals
           debug("[cookbook] Matching #{path} against ^#{re}")
           m = path.match(re)
           next unless m
+
           info("Cookbook is #{m[1]}")
           return {
             :cookbook_dir => dir,
@@ -53,6 +54,7 @@ module BetweenMeals
           links.each do |link|
             link = File.join(dir, link)
             next if symlinks[link]
+
             source = File.realpath(link)
             repo = File.join(@repo_dir, '/')
             # maps absolute symlink path to relative source and link paths
@@ -72,6 +74,7 @@ module BetweenMeals
             # a symlink will never have trailing '/', add one.
             f[:path] += '/' if f[:path] == lrp['link']
             next unless f[:path].start_with?(lrp['source'])
+
             # This make a deep dup of the file hash
             l = Marshal.load(Marshal.dump(f))
             l[:path].gsub!(lrp['source'], lrp['link'])
@@ -118,6 +121,7 @@ module BetweenMeals
         @@logger = logger
         # rubocop:enable ClassVars
         return [] if list.nil? || list.empty?
+
         # rubocop:disable MultilineBlockChain
         @repo_dir = File.realpath(repo.repo_path)
         @cookbook_dirs = cookbook_dirs

--- a/lib/between_meals/changes/databag.rb
+++ b/lib/between_meals/changes/databag.rb
@@ -42,6 +42,7 @@ module BetweenMeals
         @@logger = logger
         # rubocop:enable ClassVars
         return [] if list.nil? || list.empty?
+
         list.
           select { |x| self.name_from_path(x[:path], databag_dir) }.
           map do |x|

--- a/lib/between_meals/changes/role.rb
+++ b/lib/between_meals/changes/role.rb
@@ -43,6 +43,7 @@ module BetweenMeals
         @@logger = logger
         # rubocop:enable ClassVars
         return [] if list.nil? || list.empty?
+
         list.
           select { |x| self.name_from_path(x[:path], role_dir) }.
           map do |x|

--- a/lib/between_meals/knife.rb
+++ b/lib/between_meals/knife.rb
@@ -115,6 +115,7 @@ module BetweenMeals
         @cookbook_dirs.each do |path|
           cookbooks.each do |cb|
             next unless File.exists?("#{path}/#{cb}")
+
             @logger.warn("Running berkshelf on cookbook: #{cb}")
             exec!("cd #{path}/#{cb} && #{@berks} install #{berks_config} && " +
               "#{@berks} upload #{berks_config}", @logger)

--- a/lib/between_meals/repo/git.rb
+++ b/lib/between_meals/repo/git.rb
@@ -114,6 +114,7 @@ module BetweenMeals
         if @cmd.merge_base(rev, master).stdout.strip == rev
           return true
         end
+
         return false
       rescue StandardError
         return false

--- a/lib/between_meals/util.rb
+++ b/lib/between_meals/util.rb
@@ -94,23 +94,21 @@ module BetweenMeals
     end
 
     def chef_zero_running?(port)
-      begin
-        Timeout.timeout(1) do
-          begin
-            uri = URI("http://localhost:#{port}")
-            http = Net::HTTP.new(uri.host, uri.port)
-            http.use_ssl = true
-            http.verify_mode = OpenSSL::SSL::VERIFY_NONE
-            req = Net::HTTP::Get.new(uri.request_uri)
-            res = http.request(req)
-            return res['Server'] == 'chef-zero'
-          rescue StandardError
-            return false
-          end
+      Timeout.timeout(1) do
+        begin
+          uri = URI("http://localhost:#{port}")
+          http = Net::HTTP.new(uri.host, uri.port)
+          http.use_ssl = true
+          http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+          req = Net::HTTP::Get.new(uri.request_uri)
+          res = http.request(req)
+          return res['Server'] == 'chef-zero'
+        rescue StandardError
+          return false
         end
-      rescue Timeout::Error
-        return false
       end
+    rescue Timeout::Error
+      return false
     end
   end
 end

--- a/lib/between_meals/util.rb
+++ b/lib/between_meals/util.rb
@@ -96,14 +96,12 @@ module BetweenMeals
     def chef_zero_running?(port, use_ssl)
       Timeout.timeout(1) do
         begin
-          uri = URI("http://localhost:#{port}")
-          http = Net::HTTP.new(uri.host, uri.port)
+          http = Net::HTTP.new('localhost', port)
           if use_ssl
             http.use_ssl = true
             http.verify_mode = OpenSSL::SSL::VERIFY_NONE
           end
-          req = Net::HTTP::Get.new(uri.request_uri)
-          res = http.request(req)
+          res = http.get('/')
           return res['Server'] == 'chef-zero'
         rescue StandardError
           return false

--- a/lib/between_meals/util.rb
+++ b/lib/between_meals/util.rb
@@ -17,13 +17,15 @@
 # limitations under the License.
 
 require 'colorize'
+require 'net/http'
+require 'openssl'
 require 'socket'
 require 'timeout'
 
 module BetweenMeals
   # A set of simple utility functions used throughout BetweenMeals
   #
-  # Feel freeo to use... note that if you pass in a logger once
+  # Feel free to use... note that if you pass in a logger once
   # you don't need to again, but be safe and always pass one in. :)
 
   # Util classes need class vars :)
@@ -89,6 +91,26 @@ module BetweenMeals
         end
       end
       return false
+    end
+
+    def chef_zero_running?(port)
+      begin
+        Timeout.timeout(1) do
+          begin
+            uri = URI("http://localhost:#{port}")
+            http = Net::HTTP.new(uri.host, uri.port)
+            http.use_ssl = true
+            http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+            req = Net::HTTP::Get.new(uri.request_uri)
+            res = http.request(req)
+            return res['Server'] == 'chef-zero'
+          rescue StandardError
+            return false
+          end
+        end
+      rescue Timeout::Error
+        return false
+      end
     end
   end
 end

--- a/lib/between_meals/util.rb
+++ b/lib/between_meals/util.rb
@@ -93,13 +93,15 @@ module BetweenMeals
       return false
     end
 
-    def chef_zero_running?(port)
+    def chef_zero_running?(port, use_ssl)
       Timeout.timeout(1) do
         begin
           uri = URI("http://localhost:#{port}")
           http = Net::HTTP.new(uri.host, uri.port)
-          http.use_ssl = true
-          http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+          if use_ssl
+            http.use_ssl = true
+            http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+          end
           req = Net::HTTP::Get.new(uri.request_uri)
           res = http.request(req)
           return res['Server'] == 'chef-zero'


### PR DESCRIPTION
In taste-tester's server code, we're only checking whether the state file's port param has a process listening on it (via port_open?). Adding a new helper (chef_zero_running?) to not only check that a process is listening on the port, but specifically a chef-zero proc.
Note - a corresponding change will also be needed in taste-tester to utilize this new helper within the server (https://github.com/facebook/taste-tester/pull/94).