### PR TITLE
Remove frozen_string_literal magic comment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 source 'https://rubygems.org'
 
 gemspec

--- a/between_meals.gemspec
+++ b/between_meals.gemspec
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 Gem::Specification.new do |s|
   s.name = 'between_meals'
   s.version = '0.0.8'

--- a/lib/between_meals/changes/change.rb
+++ b/lib/between_meals/changes/change.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 
 # Copyright 2013-present Facebook

--- a/lib/between_meals/changes/cookbook.rb
+++ b/lib/between_meals/changes/cookbook.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 
 # Copyright 2013-present Facebook

--- a/lib/between_meals/changes/databag.rb
+++ b/lib/between_meals/changes/databag.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 
 # Copyright 2013-present Facebook

--- a/lib/between_meals/changes/role.rb
+++ b/lib/between_meals/changes/role.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 
 # Copyright 2013-present Facebook

--- a/lib/between_meals/changeset.rb
+++ b/lib/between_meals/changeset.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 
 # Copyright 2013-present Facebook

--- a/lib/between_meals/cmd.rb
+++ b/lib/between_meals/cmd.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 
 # Copyright 2013-present Facebook

--- a/lib/between_meals/knife.rb
+++ b/lib/between_meals/knife.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 
 # Copyright 2013-present Facebook

--- a/lib/between_meals/repo.rb
+++ b/lib/between_meals/repo.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 
 # Copyright 2013-present Facebook

--- a/lib/between_meals/repo/git.rb
+++ b/lib/between_meals/repo/git.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 
 # Copyright 2013-present Facebook

--- a/lib/between_meals/repo/git/cmd.rb
+++ b/lib/between_meals/repo/git/cmd.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 
 # Copyright 2013-present Facebook

--- a/lib/between_meals/repo/hg.rb
+++ b/lib/between_meals/repo/hg.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 
 # Copyright 2013-present Facebook

--- a/lib/between_meals/repo/hg/cmd.rb
+++ b/lib/between_meals/repo/hg/cmd.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 
 # Copyright 2013-present Facebook

--- a/lib/between_meals/repo/svn.rb
+++ b/lib/between_meals/repo/svn.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 
 # Copyright 2013-present Facebook

--- a/lib/between_meals/repo/svn/cmd.rb
+++ b/lib/between_meals/repo/svn/cmd.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 
 # Copyright 2013-present Facebook

--- a/lib/between_meals/util.rb
+++ b/lib/between_meals/util.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 
 # Copyright 2013-present Facebook

--- a/spec/cookbook_spec.rb
+++ b/spec/cookbook_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 
 # Copyright 2013-present Facebook

--- a/spec/databag_spec.rb
+++ b/spec/databag_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 
 # Copyright 2013-present Facebook

--- a/spec/git_spec.rb
+++ b/spec/git_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 
 # Copyright 2013-present Facebook

--- a/spec/hg_spec.rb
+++ b/spec/hg_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 
 # Copyright 2013-present Facebook

--- a/spec/repo_spec.rb
+++ b/spec/repo_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 
 # Copyright 2013-present Facebook

--- a/spec/role_spec.rb
+++ b/spec/role_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 
 # Copyright 2013-present Facebook

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # Copyright 2013-present Facebook
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/svn_spec.rb
+++ b/spec/svn_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 
 # Copyright 2013-present Facebook


### PR DESCRIPTION
The inclusion of this comment without refactoring the code is resulting in a user's knife config failing to  being written out or updated. We can add these comments back to the code once it has been refactored to handle frozen strings correctly and the appropriate tests added to validate functionality.

trace:
```
/opt/chefdk/embedded/lib/ruby/gems/2.4.0/gems/between_meals-0.0.8/lib/between_meals/knife.rb:188:in `block in write_user_config': can't modify frozen String (RuntimeError)
        from /opt/chefdk/embedded/lib/ruby/gems/2.4.0/gems/between_meals-0.0.8/lib/between_meals/knife.rb:187:in `each'
        from /opt/chefdk/embedded/lib/ruby/gems/2.4.0/gems/between_meals-0.0.8/lib/between_meals/knife.rb:187:in `write_user_config'
        from /opt/chefdk/embedded/lib/ruby/gems/2.4.0/gems/taste_tester-0.0.13/lib/taste_tester/server.rb:149:in `write_config'
        from /opt/chefdk/embedded/lib/ruby/gems/2.4.0/gems/taste_tester-0.0.13/lib/taste_tester/server.rb:90:in `start'
        from /opt/chefdk/embedded/lib/ruby/gems/2.4.0/gems/taste_tester-0.0.13/lib/taste_tester/commands.rb:35:in `start'
        from /opt/chefdk/embedded/lib/ruby/gems/2.4.0/gems/taste_tester-0.0.13/bin/taste-tester:392:in `<module:TasteTester>'
        from /opt/chefdk/embedded/lib/ruby/gems/2.4.0/gems/taste_tester-0.0.13/bin/taste-tester:34:in `<top (required)>'
        from /opt/chefdk/embedded/bin/taste-tester:23:in `load'
        from /opt/chefdk/embedded/bin/taste-tester:23:in `<main>'
```