### PR TITLE
Fix logging in hg repo update.

### DIFF
--- a/lib/between_meals/repo/hg.rb
+++ b/lib/between_meals/repo/hg.rb
@@ -65,9 +65,9 @@ module BetweenMeals
 
       def update
         @cmd.pull.stdout
-      rescue StandardError
+      rescue StandardError => e
         @logger.error('Something went wrong with hg!')
-        @logger.error(cmd.stdout)
+        @logger.error(e)
         raise
       end
 


### PR DESCRIPTION
If `hg pull` fails shell out throws exception, we catch it and try to log cmd.stdout. There are 2 issues with this:
1. cmd is not defined, but there is @cmd
2. The cmd object with stdout is returned as result as call, but since it's interruped with exception, we cannot get that stdout.

However, the exception itself includes everything, including stdout, so log the exception to have an info about the error logged.