### PR TITLE
change cookbook status from deleted -> modified for cookbooks with both deletions and additions

### DIFF
--- a/lib/between_meals/changes/cookbook.rb
+++ b/lib/between_meals/changes/cookbook.rb
@@ -104,7 +104,8 @@ module BetweenMeals
              x[:path].match(
                %{^(#{cookbook_dirs.join('|')})/[^/]+/metadata\.(rb|json)$},
              )
-           end.none?
+           end.none? &&
+           files.select { |x| x[:status] == :added }.none?
           @status = :deleted
         else
           @status = :modified

--- a/lib/between_meals/changes/cookbook.rb
+++ b/lib/between_meals/changes/cookbook.rb
@@ -30,6 +30,7 @@ module BetweenMeals
           debug("[cookbook] Matching #{path} against ^#{re}")
           m = path.match(re)
           next unless m
+
           info("Cookbook is #{m[1]}")
           return {
             :cookbook_dir => dir,
@@ -53,6 +54,7 @@ module BetweenMeals
           links.each do |link|
             link = File.join(dir, link)
             next if symlinks[link]
+
             source = File.realpath(link)
             repo = File.join(@repo_dir, '/')
             # maps absolute symlink path to relative source and link paths
@@ -72,6 +74,7 @@ module BetweenMeals
             # a symlink will never have trailing '/', add one.
             f[:path] += '/' if f[:path] == lrp['link']
             next unless f[:path].start_with?(lrp['source'])
+
             # This make a deep dup of the file hash
             l = Marshal.load(Marshal.dump(f))
             l[:path].gsub!(lrp['source'], lrp['link'])
@@ -119,6 +122,7 @@ module BetweenMeals
         @@logger = logger
         # rubocop:enable ClassVars
         return [] if list.nil? || list.empty?
+
         # rubocop:disable MultilineBlockChain
         @repo_dir = File.realpath(repo.repo_path)
         @cookbook_dirs = cookbook_dirs

--- a/lib/between_meals/changes/databag.rb
+++ b/lib/between_meals/changes/databag.rb
@@ -42,6 +42,7 @@ module BetweenMeals
         @@logger = logger
         # rubocop:enable ClassVars
         return [] if list.nil? || list.empty?
+
         list.
           select { |x| self.name_from_path(x[:path], databag_dir) }.
           map do |x|

--- a/lib/between_meals/changes/role.rb
+++ b/lib/between_meals/changes/role.rb
@@ -43,6 +43,7 @@ module BetweenMeals
         @@logger = logger
         # rubocop:enable ClassVars
         return [] if list.nil? || list.empty?
+
         list.
           select { |x| self.name_from_path(x[:path], role_dir) }.
           map do |x|

--- a/lib/between_meals/knife.rb
+++ b/lib/between_meals/knife.rb
@@ -115,6 +115,7 @@ module BetweenMeals
         @cookbook_dirs.each do |path|
           cookbooks.each do |cb|
             next unless File.exists?("#{path}/#{cb}")
+
             @logger.warn("Running berkshelf on cookbook: #{cb}")
             exec!("cd #{path}/#{cb} && #{@berks} install #{berks_config} && " +
               "#{@berks} upload #{berks_config}", @logger)

--- a/lib/between_meals/repo/git.rb
+++ b/lib/between_meals/repo/git.rb
@@ -114,6 +114,7 @@ module BetweenMeals
         if @cmd.merge_base(rev, master).stdout.strip == rev
           return true
         end
+
         return false
       rescue StandardError
         return false

--- a/spec/databag_spec.rb
+++ b/spec/databag_spec.rb
@@ -64,7 +64,7 @@ describe BetweenMeals::Changes::Databag do
         },
         {
           :status => :deleted,
-          :path => 'databags/test/databag2.rb' # wrong extension
+          :path => 'databags/test/databag2.rb', # wrong extension
         },
         {
           :status => :deleted,


### PR DESCRIPTION
Cookbooks that have both repo deletions and additions are currently marked as status 'deleted'. This is causing taste-tester issues for a cookbook that was deleted and replaced a symlinked cookbook of the same name (hg status --rev shows this cookbook was both added and removed). Taste-tester is knife deleting this cookbook, then failing dependent cookbook uploads, as the deleted cookbook is no longer being served by chef-zero. The only current way to resolve this is doing a forced upload.

Instead of deleted, we should mark these cookbooks as modified.