### PR TITLE
Fix classification of cookbooks replaced with symlink

### DIFF
--- a/lib/between_meals/changes/cookbook.rb
+++ b/lib/between_meals/changes/cookbook.rb
@@ -71,6 +71,19 @@ module BetweenMeals
           files.each do |f|
             # a symlink will never have trailing '/', add one.
             f[:path] += '/' if f[:path] == lrp['link']
+
+            # If a metadata file in the path of a symlink target directory has a
+            # deleted status, check if a metadata file exists in the symlink
+            # source directory. If so, mark it as modified to prevent deletion.
+            symlink_source_dir = File.join(@repo_dir, lrp['source'])
+            if (f[:path] == File.join(lrp['link'], 'metadata.rb') ||
+                f[:path] == File.join(lrp['link'], 'metadata.json')) &&
+                f[:status] == :deleted &&
+                (File.file?(File.join(symlink_source_dir, 'metadata.rb')) ||
+                 File.file?(File.join(symlink_source_dir, 'metadata.json')))
+              f[:status] = :modified
+            end
+
             next unless f[:path].start_with?(lrp['source'])
 
             # This make a deep dup of the file hash

--- a/spec/cookbook_spec.rb
+++ b/spec/cookbook_spec.rb
@@ -234,6 +234,28 @@ describe BetweenMeals::Changes::Cookbook do
       :result => [],
       :result_with_symlink_tracking => [['cb_one', :modified]],
     },
+    {
+      :name => 'replacing metadata file with symlink',
+      :files => [
+        {
+          :status => :deleted,
+          :path => 'cookbooks/three/cb_one/metadata.rb',
+        },
+      ],
+      :result => [['cb_one', :deleted]],
+      :result_with_symlink_tracking => [['cb_one', :modified]],
+    },
+    {
+      :name => 'replacing non-metadata file with symlink',
+      :files => [
+        {
+          :status => :deleted,
+          :path => 'cookbooks/three/OWNERS',
+        },
+      ],
+      :result => [],
+      :result_with_symlink_tracking => [],
+    },
   ]
 
   {
@@ -255,6 +277,12 @@ describe BetweenMeals::Changes::Cookbook do
             allow(Dir).to receive(:foreach).with(repo).and_return(find_res)
             allow(File).to receive(:symlink?).and_return(true)
             allow(File).to receive(:realpath).with(link).and_return(src)
+            allow(File).to receive(:file?).with(
+              File.join(repo_path, src, 'metadata.rb'),
+            ).and_return(true)
+            allow(File).to receive(:file?).with(
+              File.join(repo_path, src, 'OWNERS'),
+            ).and_return(true)
           end
         end
       end

--- a/spec/cookbook_spec.rb
+++ b/spec/cookbook_spec.rb
@@ -235,7 +235,22 @@ describe BetweenMeals::Changes::Cookbook do
       :result_with_symlink_tracking => [['cb_one', :modified]],
     },
     {
-      :name => 'replacing metadata file with symlink',
+      :name => 'replacing metadata file with new symlink',
+      :files => [
+        {
+          :status => :deleted,
+          :path => 'cookbooks/three/cb_one/metadata.rb',
+        },
+        {
+          :status => :added,
+          :path => 'cookbooks/one/cb_one/metadata.rb',
+        },
+      ],
+      :result => [['cb_one', :deleted], ['cb_one', :modified]],
+      :result_with_symlink_tracking => [['cb_one', :modified]],
+    },
+    {
+      :name => 'replacing metadata file with existing symlink',
       :files => [
         {
           :status => :deleted,

--- a/spec/databag_spec.rb
+++ b/spec/databag_spec.rb
@@ -62,7 +62,7 @@ describe BetweenMeals::Changes::Databag do
         },
         {
           :status => :deleted,
-          :path => 'databags/test/databag2.rb' # wrong extension
+          :path => 'databags/test/databag2.rb', # wrong extension
         },
         {
           :status => :deleted,


### PR DESCRIPTION
Cookbooks that have been deleted and replaced with a symlinked cookbook in a changeset are currently marked as status 'deleted' instead of 'modified'. Taste-tester is knife deleting this cookbook, then failing dependent cookbook uploads, as the deleted cookbook is no longer being served by chef-zero. The only current way to resolve this is doing a forced upload.

To fix this - when processing symlinks, if we come across a metadata file that is marked as 'deleted', check in the symlink source directory if a metadata file exists. If so mark the metadata file as 'modified' and allow knife to re-upload rather than delete the cookbook.