### PR TITLE
Allow spaces in file paths when parsing change between revs

### DIFF
--- a/lib/between_meals/repo/hg.rb
+++ b/lib/between_meals/repo/hg.rb
@@ -167,37 +167,37 @@ module BetweenMeals
 
         changes.lines.map do |line|
           case line
-          when /^A (\S+)$/
+          when /^A (.+)$/
             {
               :status => :added,
               :path => Regexp.last_match(1),
             }
-          when /^C (\S+)$/
+          when /^C (.+)$/
             {
               :status => :clean,
               :path => Regexp.last_match(1),
             }
-          when /^R (\S+)$/
+          when /^R (.+)$/
             {
               :status => :deleted,
               :path => Regexp.last_match(1),
             }
-          when /^M (\S+)$/
+          when /^M (.+)$/
             {
               :status => :modified,
               :path => Regexp.last_match(1),
             }
-          when /^! (\S+)$/
+          when /^! (.+)$/
             {
               :status => :missing,
               :path => Regexp.last_match(1),
             }
-          when /^\? (\S+)$/
+          when /^\? (.+)$/
             {
               :status => :untracked,
               :path => Regexp.last_match(1),
             }
-          when /^I (\S+)$/
+          when /^I (.+)$/
             {
               :status => :ignored,
               :path => Regexp.last_match(1),

--- a/lib/between_meals/repo/svn.rb
+++ b/lib/between_meals/repo/svn.rb
@@ -102,7 +102,7 @@ module BetweenMeals
         # http://svnbook.red-bean.com/en/1.0/re26.html
         changes.lines.map do |line|
           case line
-          when /^([\w ])\w?\s+(\S+)$/
+          when /^([\w ])\w?\s+(.+)$/
             {
               :status => Regexp.last_match(1) == 'D' ? :deleted : :modified,
               :path => Regexp.last_match(2).sub("#{@repo_path}/", ''),

--- a/spec/hg_spec.rb
+++ b/spec/hg_spec.rb
@@ -38,6 +38,13 @@ describe BetweenMeals::Repo::Hg do
       ],
     },
     {
+      :name => 'handle additions with spaces',
+      :changes => 'A bar/baz bot',
+      :result => [
+        { :status => :added, :path => 'bar/baz bot' },
+      ],
+    },
+    {
       :name => 'handle deletes',
       :changes => 'R bar/baz',
       :result => [
@@ -45,10 +52,24 @@ describe BetweenMeals::Repo::Hg do
       ],
     },
     {
+      :name => 'handle deletes with spaces',
+      :changes => 'R bar/baz bot',
+      :result => [
+        { :status => :deleted, :path => 'bar/baz bot' },
+      ],
+    },
+    {
       :name => 'handle modifications',
       :changes => 'M bar/baz',
       :result => [
         { :status => :modified, :path => 'bar/baz' },
+      ],
+    },
+    {
+      :name => 'handle modifications with spaces',
+      :changes => 'M bar/baz bot',
+      :result => [
+        { :status => :modified, :path => 'bar/baz bot' },
       ],
     },
     {
@@ -119,15 +140,6 @@ describe BetweenMeals::Repo::Hg do
       expect(hg.email).to eq(example[:email])
       expect(hg.name).to eq(example[:name])
     end
-  end
-
-  it 'should error on spaces in file names' do
-    allow_any_instance_of(BetweenMeals::Repo::Hg).
-      to receive(:setup).and_return(true)
-    hg = BetweenMeals::Repo::Hg.new('foo', logger)
-    expect(lambda do
-      hg.send(:parse_status, 'M foo/bar baz')
-    end).to raise_error('Failed to parse repo diff line.')
   end
 
   it 'should handle malformed output' do

--- a/spec/svn_spec.rb
+++ b/spec/svn_spec.rb
@@ -33,6 +33,13 @@ describe BetweenMeals::Repo::Svn do
       ],
     },
     {
+      :name => 'handle additions with files with spaces',
+      :changes => 'A foo/bar/baz bot',
+      :result => [
+        { :status => :modified, :path => 'bar/baz bot' },
+      ],
+    },
+    {
       :name => 'handle file modifications',
       :changes => 'M foo/bar/baz',
       :result => [
@@ -54,6 +61,13 @@ describe BetweenMeals::Repo::Svn do
       ],
     },
     {
+      :name => 'handle attribute modifications on files with spaces',
+      :changes => ' M foo/bar/baz bot',
+      :result => [
+        { :status => :modified, :path => 'bar/baz bot' },
+      ],
+    },
+    {
       :name => 'handle file & attribute modifications',
       :changes => 'MM foo/bar/baz',
       :result => [
@@ -61,10 +75,24 @@ describe BetweenMeals::Repo::Svn do
       ],
     },
     {
+      :name => 'handle file & attribute modifications on files with spaces',
+      :changes => 'MM foo/bar/baz bot',
+      :result => [
+        { :status => :modified, :path => 'bar/baz bot' },
+      ],
+    },
+    {
       :name => 'handle deletes',
       :changes => 'D foo/bar/baz',
       :result => [
         { :status => :deleted, :path => 'bar/baz' },
+      ],
+    },
+    {
+      :name => 'handle deletes for files with spaces',
+      :changes => 'D foo/bar/baz bot',
+      :result => [
+        { :status => :deleted, :path => 'bar/baz bot' },
       ],
     },
   ]
@@ -77,15 +105,6 @@ describe BetweenMeals::Repo::Svn do
       expect(svn.send(:parse_status, fixture[:changes])).
         to eq(fixture[:result])
     end
-  end
-
-  it 'should error on spaces in file names' do
-    expect_any_instance_of(BetweenMeals::Repo::Svn).
-      to receive(:setup).and_return(true)
-    svn = BetweenMeals::Repo::Svn.new('foo', logger)
-    expect(lambda do
-      svn.send(:parse_status, 'M foo/bar baz')
-    end).to raise_error('Failed to parse repo diff line.')
   end
 
   it 'should handle malformed output' do


### PR DESCRIPTION
If BM encounters a change that includes a file path with a space, it breaks.  This changes the regex which maps a change in a given repository type to capture any character rather than only non whitespace.  I can't find any other aspect of the parsing which depends on spaces, so I think this'll work.