### PR TITLE
Pull changes from HG server in two steps

### DIFF
--- a/lib/between_meals/repo/hg/cmd.rb
+++ b/lib/between_meals/repo/hg/cmd.rb
@@ -34,7 +34,8 @@ module BetweenMeals
         end
 
         def pull
-          cmd('pull --rebase')
+          cmd('pull')
+          cmd('checkout master --clean')
         end
 
         def manifest


### PR DESCRIPTION
Summary: This will switch how 'hg' is doing pull.
Iriginally 'hg pull --rebase' used. The problem that it's not selfhealing. If for some reason working copy
has modified files - rebase often fails. Instead use two steps:
1) 'hg pull'
2) 'hg co master --clean'

This will allow to recover from localy modified files.

Test Plan:
 /opt/chefdk/embedded/bin/ruby /opt/chefdk/embedded/bin/grocery-delivery -v -c /etc/gd-config.rb
WARN: Attempting to acquire lock
WARN: Lock acquired
WARN: Updating repo
INFO: Running "/usr/local/libexec/hg_wrapper_facebook pull"
INFO: Running "/usr/local/libexec/hg_wrapper_facebook checkout master --clean"
INFO: Running "/usr/local/libexec/hg_wrapper_facebook log -r . -l 1 -T '{node}'"
WARN: Repo has not changed, nothing to do...
WARN: Success at 93c6f4814b579a2724b727c46ad8808754b85bed