### PR TITLE
Don't fail taste-tester when working directory already exists

### DIFF
--- a/lib/between_meals/knife.rb
+++ b/lib/between_meals/knife.rb
@@ -241,8 +241,12 @@ IAMAEpsWX2s2A6phgMCx7kH6wMmoZn3hb7Thh9+PfR8Jtp2/7k+ibCeF4gEWUCs5
 -----END PRIVATE KEY-----
       BLOCK
 
-      unless File.directory?(File.dirname(@pem))
-        Dir.mkdir(File.dirname(@pem), 0o755)
+      begin
+        unless File.directory?(File.dirname(@pem))
+          Dir.mkdir(File.dirname(@pem), 0o755)
+        end
+      rescue Errno::EEXIST => e
+        @logger.warn("#{File.dirname(@pem)} already exists, not creating: #{e}")
       end
 
       unless File.exists?(@pem)


### PR DESCRIPTION
Creation of the working directory for taste-tester can fail when multiple instances try to make the directory; it's possible for the directory to not exist, such that the gate is passed, but then it exists before the mkdir call.