### PR TITLE
Eliminate mkdir race condition

### DIFF
--- a/lib/between_meals/knife.rb
+++ b/lib/between_meals/knife.rb
@@ -199,8 +199,11 @@ BLOCK
         cfg << "  \"#{dir}\",\n"
       end
       cfg << "]\n"
-      unless File.directory?(File.dirname(@config))
+      begin
         Dir.mkdir(File.dirname(@config), 0o755)
+      rescue Errno::EEXIST
+        # not an error if it's already there.
+        nil
       end
       if !File.exists?(@config) ||
          ::Digest::MD5.hexdigest(cfg) !=
@@ -242,11 +245,10 @@ IAMAEpsWX2s2A6phgMCx7kH6wMmoZn3hb7Thh9+PfR8Jtp2/7k+ibCeF4gEWUCs5
       BLOCK
 
       begin
-        unless File.directory?(File.dirname(@pem))
-          Dir.mkdir(File.dirname(@pem), 0o755)
-        end
-      rescue Errno::EEXIST => e
-        @logger.warn("#{File.dirname(@pem)} already exists, not creating: #{e}")
+        Dir.mkdir(File.dirname(@pem), 0o755)
+      rescue Errno::EEXIST
+        # not an error if it's already there.
+        nil
       end
 
       unless File.exists?(@pem)


### PR DESCRIPTION
Some automation ends up running multiple copies of between_meals. I have
observed situations where the directory didn't exist, but by the time
mkdir was called, it did, so it crashed out. This uses similar logic to
FileUtils.mkdir_p to try to create the directory in any case, accept
failures as part of normal practice, and raise errors if the directory
*didn't* get created.