### PR TITLE
Better handling for git config

### DIFF
--- a/lib/between_meals/cmd.rb
+++ b/lib/between_meals/cmd.rb
@@ -26,7 +26,7 @@ module BetweenMeals
       @logger = params[:logger] || Logger.new(STDOUT)
     end
 
-    def cmd(params, cwd = nil)
+    def cmd(params, cwd = nil, nofail = false)
       cwd ||= File.expand_path(@cwd)
       cmd = "#{@bin} #{params}"
       @logger.info("Running \"#{cmd}\"")
@@ -40,7 +40,8 @@ module BetweenMeals
         },
       )
       c.run_command
-      if c.error?
+      # If the user asked us not to fail, let them handle error reporting
+      if c.error? && !nofail
         # Let's make sure the error goes to the logs
         @logger.error("#{@bin} failed: #{c.format_for_exception}")
         # if our logger is STDOUT, we'll double log when we throw

--- a/lib/between_meals/repo.rb
+++ b/lib/between_meals/repo.rb
@@ -31,6 +31,7 @@ module BetweenMeals
       @logger.warn("Unable to read repo from #{File.expand_path(repo_path)}")
       exit(1)
     end
+
     def self.get(type, repo_path, logger)
       case type
       when 'auto'
@@ -72,7 +73,6 @@ module BetweenMeals
         fail "Do not know repo type #{type}"
       end
     end
-    # rubocop:enable Style/RedundantBegin
 
     def bin=(bin)
       @bin = bin

--- a/lib/between_meals/repo.rb
+++ b/lib/between_meals/repo.rb
@@ -31,8 +31,6 @@ module BetweenMeals
       @logger.warn("Unable to read repo from #{File.expand_path(repo_path)}")
       exit(1)
     end
-
-    # rubocop:disable Style/RedundantBegin
     def self.get(type, repo_path, logger)
       case type
       when 'auto'

--- a/lib/between_meals/repo/git/cmd.rb
+++ b/lib/between_meals/repo/git/cmd.rb
@@ -21,7 +21,11 @@ module BetweenMeals
     class Git < BetweenMeals::Repo
       class Cmd < BetweenMeals::Cmd
         def config(key)
-          cmd("config #{key}")
+          s = cmd("config #{key}", nil, true)
+          unless [0, 1].include?(s.exitstatus)
+            s.error!
+          end
+          s
         end
 
         def clone(url, repo_path)

--- a/lib/between_meals/util.rb
+++ b/lib/between_meals/util.rb
@@ -110,7 +110,6 @@ module BetweenMeals
     rescue Timeout::Error
       return false
     end
-    # rubocop:enable Style/RedundantBegin
   end
 end
 # rubocop:enable ClassVars

--- a/lib/between_meals/util.rb
+++ b/lib/between_meals/util.rb
@@ -71,7 +71,6 @@ module BetweenMeals
       return c
     end
 
-    # while we support ruby 2.4
     def port_open?(port)
       ips = Socket.ip_address_list
       ips.map!(&:ip_address)

--- a/lib/between_meals/util.rb
+++ b/lib/between_meals/util.rb
@@ -72,7 +72,6 @@ module BetweenMeals
     end
 
     # while we support ruby 2.4
-    # rubocop:disable Style/RedundantBegin
     def port_open?(port)
       ips = Socket.ip_address_list
       ips.map!(&:ip_address)


### PR DESCRIPTION
Currently if `user.email` or `user.name` are not set, `git config`
returns an error. This means that if, if you're taste-tester plugin
you check to see if it's config, taste-tester just blows up deep
inside the bowels of between-meals, which is suboptimal.

Since `git config` returns 1 in the case of no config set, let's
accept that as a valid response.