### PR TITLE
Do not assume git-svn in the git plugin

### DIFF
--- a/lib/between_meals/repo/git.rb
+++ b/lib/between_meals/repo/git.rb
@@ -108,7 +108,7 @@ module BetweenMeals
         @repo.index.map { |x| { :path => x[:path], :status => :created } }
       end
 
-      def upstream?(rev, master = 'remotes/trunk')
+      def upstream?(rev, master = 'upstream/master')
         if @cmd.merge_base(rev, master).stdout.strip == rev
           return true
         end


### PR DESCRIPTION
I know that FB's git was git-over-svn, but that's not the common-case,
so default to a more common git case.

Since nearly everyone is already overriding this who uses it, and FB
no longer uses git, this should be safe.