### PR TITLE
Allow users to get access to the Rugged object

### DIFF
--- a/lib/between_meals/repo.rb
+++ b/lib/between_meals/repo.rb
@@ -87,6 +87,12 @@ module BetweenMeals
       fail "#{__method__} not implemented"
     end
 
+    # Only interesting in the case of git where we have an underlying
+    # repo object courtesy of Rugged.
+    def repo_object
+      fail "#{__method__} not implemented"
+    end
+
     # This method *must* succeed in the case of no repo directory so that
     # users can call `checkout`. Users may call `exists?` to find out if
     # we have an underlying repo yet.

--- a/lib/between_meals/repo/git.rb
+++ b/lib/between_meals/repo/git.rb
@@ -43,6 +43,12 @@ module BetweenMeals
         )
       end
 
+      # Allow people to get access to the underlying Rugged
+      # object for their hooks
+      def repo_object
+        @repo
+      end
+
       def exists?
         !@repo.nil?
       end


### PR DESCRIPTION
For the repo checks hook it's useful to get access to the rugged object
to do sanity checks without having to shell out. This provides an
accessor.

It's done specifically in the git module because it's the only module
in which we use such a library, the other ones are simple shellouts.