### PR TITLE
Update default branch name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: Continuous Integration
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
 jobs:
   ruby:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ RubyGems.
 ## Pull Requests
 We actively welcome your pull requests.
 
-1. Fork the repo and create your branch from `master`.
+1. Fork the repo and create your branch from `main`.
 1. If you've added code that should be tested, add tests.
 1. If you've changed APIs, update the documentation.
 1. Ensure the test suite passes.


### PR DESCRIPTION
The default branch is now named "main", updating workflows and documentation to reflect the change