### PR TITLE
De-couple BetweenMeals::Repo class conformance tests

### DIFF
--- a/spec/git_spec.rb
+++ b/spec/git_spec.rb
@@ -18,8 +18,12 @@ require 'spec_helper'
 require 'between_meals/repo/git'
 require 'between_meals/repo.rb'
 require 'logger'
+require_relative 'repo_subclass_conformance'
 
 describe BetweenMeals::Repo::Git do
+  context 'conforms to BetweenMeals::Repo interfaces' do
+    it_behaves_like 'Repo subclass conformance', BetweenMeals::Repo::Git
+  end
   let(:logger) do
     Logger.new('/dev/null')
   end

--- a/spec/hg_spec.rb
+++ b/spec/hg_spec.rb
@@ -18,8 +18,12 @@ require 'spec_helper'
 require 'between_meals/repo/hg'
 require 'between_meals/repo.rb'
 require 'logger'
+require_relative 'repo_subclass_conformance'
 
 describe BetweenMeals::Repo::Hg do
+  context 'conforms to BetweenMeals::Repo interfaces' do
+    it_behaves_like 'Repo subclass conformance', BetweenMeals::Repo::Git
+  end
   let(:logger) do
     Logger.new('/dev/null')
   end

--- a/spec/repo_subclass_conformance.rb
+++ b/spec/repo_subclass_conformance.rb
@@ -15,25 +15,15 @@
 # limitations under the License.
 
 require 'between_meals/repo'
-require 'between_meals/repo/git'
-require 'between_meals/repo/svn'
 
-describe 'BetweenMeals::Repo' do
+shared_examples 'Repo subclass conformance' do |klass|
   let(:class_interface) { BetweenMeals::Repo.public_methods.sort }
   let(:instance_interface) { BetweenMeals::Repo.instance_methods.sort }
 
-  # Misc Repos should not expose anything more than parent class,
-  # which default to 'Not implemented'
-  [
-    BetweenMeals::Repo::Git,
-    BetweenMeals::Repo::Svn,
-    BetweenMeals::Repo::Hg,
-  ].each do |klass|
-    it "#{klass} should conform to BetweenMeals::Repo class interface" do
-      expect(klass.public_methods.sort).to eq(class_interface)
-    end
-    it "#{klass} should conform to BetweenMeals::Repo instance interface" do
-      expect(klass.instance_methods.sort).to eq(instance_interface)
-    end
+  it "#{klass} should conform to BetweenMeals::Repo class interface" do
+    expect(klass.public_methods.sort).to eq(class_interface)
+  end
+  it "#{klass} should conform to BetweenMeals::Repo instance interface" do
+    expect(klass.instance_methods.sort).to eq(instance_interface)
   end
 end

--- a/spec/svn_spec.rb
+++ b/spec/svn_spec.rb
@@ -18,8 +18,12 @@ require 'spec_helper'
 require 'between_meals/repo/svn'
 require 'between_meals/repo.rb'
 require 'logger'
+require_relative 'repo_subclass_conformance'
 
 describe BetweenMeals::Repo::Svn do
+  context 'conforms to BetweenMeals::Repo interfaces' do
+    it_behaves_like 'Repo subclass conformance', BetweenMeals::Repo::Svn
+  end
   let(:logger) do
     Logger.new('/dev/null')
   end


### PR DESCRIPTION
The aim of this refactor is to make the BetweenMeals internals testing more repo-agnostic, isolating RCS-specific issues (ie rugged/git) to specific class tests.