### PR TITLE
Fix change detection for databags

### DIFF
--- a/lib/between_meals/changes/change.rb
+++ b/lib/between_meals/changes/change.rb
@@ -34,8 +34,8 @@ module BetweenMeals
       end
 
       def status=(value)
-        if ALLOWED_STATUSES.exclude?(@value)
-          fail "#{self.class} status attribute can only be one of #{ALLOWED_STATUSES}"
+        unless ALLOWED_STATUSES.include?(value)
+          fail "#{self.class} status attribute can only be one of #{ALLOWED_STATUSES} not #{value}"
         end
         @status = value
       end

--- a/lib/between_meals/changes/change.rb
+++ b/lib/between_meals/changes/change.rb
@@ -24,11 +24,20 @@ module BetweenMeals
   module Changes
     # Common functionality
     class Change
+      ALLOWED_STATUSES = [:modified, :deleted].freeze
       @@logger = nil
-      attr_accessor :name, :status
+      attr_accessor :name
+      attr_reader :status
 
       def to_s
         @name
+      end
+
+      def status=(value)
+        if ALLOWED_STATUSES.exclude?(@value)
+          fail "#{self.class} status attribute can only be one of #{ALLOWED_STATUSES}"
+        end
+        @status = value
       end
 
       # People who use us through find() can just pass in logger,

--- a/lib/between_meals/changes/change.rb
+++ b/lib/between_meals/changes/change.rb
@@ -24,6 +24,10 @@ module BetweenMeals
   module Changes
     # Common functionality
     class Change
+      # Since we either need to upload or delete, we only accept two statuses.
+      # VCSs will differentiate between various kinds of modifies, adds, etc.
+      # so instead of handling all possibilities here, we expect the caller to
+      # collapse them into `:modified` or `:deleted`.
       ALLOWED_STATUSES = [:modified, :deleted].freeze
       @@logger = nil
       attr_accessor :name

--- a/lib/between_meals/changes/cookbook.rb
+++ b/lib/between_meals/changes/cookbook.rb
@@ -119,9 +119,9 @@ module BetweenMeals
                %{^(#{cookbook_dirs.join('|')})/[^/]+/metadata\.(rb|json)$},
              )
            end.none?
-          @status = :deleted
+          self.status = :deleted
         else
-          @status = :modified
+          self.status = :modified
         end
       end
 

--- a/lib/between_meals/changes/databag.rb
+++ b/lib/between_meals/changes/databag.rb
@@ -32,7 +32,7 @@ module BetweenMeals
       end
 
       def initialize(file, databag_dir)
-        @status = file[:status]
+        @status = file[:status] == :deleted ? :deleted : :modified
         @name, @item = self.class.name_from_path(file[:path], databag_dir)
       end
 

--- a/lib/between_meals/changes/databag.rb
+++ b/lib/between_meals/changes/databag.rb
@@ -32,8 +32,8 @@ module BetweenMeals
       end
 
       def initialize(file, databag_dir)
-        @status = file[:status] == :deleted ? :deleted : :modified
-        @name, @item = self.class.name_from_path(file[:path], databag_dir)
+        self.status = file[:status] == :deleted ? :deleted : :modified
+        self.name, self.item = self.class.name_from_path(file[:path], databag_dir)
       end
 
       def self.find(list, databag_dir, logger)

--- a/lib/between_meals/changes/role.rb
+++ b/lib/between_meals/changes/role.rb
@@ -30,8 +30,8 @@ module BetweenMeals
       end
 
       def initialize(file, role_dir)
-        @status = file[:status] == :deleted ? :deleted : :modified
-        @name = self.class.name_from_path(file[:path], role_dir)
+        self.status = file[:status] == :deleted ? :deleted : :modified
+        self.name = self.class.name_from_path(file[:path], role_dir)
       end
 
       # Given a list of changed files

--- a/spec/cookbook_spec.rb
+++ b/spec/cookbook_spec.rb
@@ -162,6 +162,18 @@ describe BetweenMeals::Changes::Cookbook do
       ],
     },
     {
+      :name => 'adding recipe',
+      :files => [
+        {
+          :status => :added,
+          :path => 'cookbooks/one/cb_one/recipe/extra.rb',
+        },
+      ],
+      :result => [
+        ['cb_one', :modified],
+      ],
+    },
+    {
       :name => 'skipping non-cookbook files',
       :files => [
         {

--- a/spec/databag_spec.rb
+++ b/spec/databag_spec.rb
@@ -68,9 +68,13 @@ describe BetweenMeals::Changes::Databag do
           :status => :deleted,
           :path => 'databags/two/databag3.json',
         },
+        {
+          :status => :added,
+          :path => 'databags/three/databag1.json',
+        },
       ],
       :result => [
-        ['one', :modified], ['two', :deleted]
+        ['one', :modified], ['two', :deleted], ['three', :modified]
       ],
     },
   ]

--- a/spec/role_spec.rb
+++ b/spec/role_spec.rb
@@ -86,7 +86,8 @@ describe BetweenMeals::Changes::Role do
         },
       ],
       :result => [
-        ['test', :modified], ['test2', :modified],
+        ['test', :modified],
+        ['test2', :modified],
       ],
     },
     {

--- a/spec/role_spec.rb
+++ b/spec/role_spec.rb
@@ -77,12 +77,16 @@ describe BetweenMeals::Changes::Role do
           :path => 'roles/test.rb',
         },
         {
+          :status => :added,
+          :path => 'roles/test2.rb',
+        },
+        {
           :status => :modified,
           :path => 'cookbooks/one/cb_one/recipes/test3.rb',
         },
       ],
       :result => [
-        ['test', :modified],
+        ['test', :modified], ['test2', :modified],
       ],
     },
     {


### PR DESCRIPTION
Summary:
For changes detection we don't care if file was added or modified or have any other status provided by VCS, we only need to understand if file was modified or deleted. So using same logic as in BetweenMeals::Changes::Role

This would fix an issue with Grocery Delivery uploads when adding new databag.