### PR TITLE
Move rugged dependency into git gem group

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,10 @@ source 'https://rubygems.org'
 
 gemspec
 
+group :git do
+  gem 'rugged'
+end
+
 group :development do
   gem 'rspec-core', '~> 3.11'
   gem 'rspec-expectations', '~> 3.11'

--- a/between_meals.gemspec
+++ b/between_meals.gemspec
@@ -32,5 +32,4 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.5.0'
   s.add_dependency 'colorize'
   s.add_dependency 'mixlib-shellout'
-  s.add_dependency 'rugged'
 end


### PR DESCRIPTION
With 396dd8f4d3c7dcae9825951cad906ee2b98ca78b committed, we can put `rugged` into a gemfile group, which allows `bundle install --without git`