### PR TITLE
Remove verbosity options from data bag list shellout

### DIFF
--- a/lib/between_meals/knife.rb
+++ b/lib/between_meals/knife.rb
@@ -261,7 +261,7 @@ IAMAEpsWX2s2A6phgMCx7kH6wMmoZn3hb7Thh9+PfR8Jtp2/7k+ibCeF4gEWUCs5
 
     def create_databag_if_missing(databag)
       s = Mixlib::ShellOut.new("#{@knife} data bag list" +
-                               " --format json #{@knife_verb_option} " +
+                               " --format json " +
                                "-c #{@config}").run_command
       s.error!
       db = JSON.parse(s.stdout)

--- a/lib/between_meals/knife.rb
+++ b/lib/between_meals/knife.rb
@@ -261,7 +261,7 @@ IAMAEpsWX2s2A6phgMCx7kH6wMmoZn3hb7Thh9+PfR8Jtp2/7k+ibCeF4gEWUCs5
 
     def create_databag_if_missing(databag)
       s = Mixlib::ShellOut.new("#{@knife} data bag list" +
-                               " --format json " +
+                               ' --format json ' +
                                "-c #{@config}").run_command
       s.error!
       db = JSON.parse(s.stdout)


### PR DESCRIPTION
We're expecting the output of `knife data bag list` to be JSON, but with `-VV` this can have non-JSON output which looks like:
```
Uploading databags...
Upload failed
unexpected token at 'INFO: Using configuration from /fake/.chef/knife-dcrosby-taste-tester.rb
[
  "foo"
]
'
```