### PR TITLE
Create interface import of repo types

### DIFF
--- a/lib/between_meals/repo.rb
+++ b/lib/between_meals/repo.rb
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 require 'mixlib/shellout'
+require 'between_meals/repo/if'
 
 module BetweenMeals
   # Local checkout wrapper

--- a/lib/between_meals/repo/if.rb
+++ b/lib/between_meals/repo/if.rb
@@ -1,0 +1,26 @@
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+
+# Copyright 2024-present Facebook
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module BetweenMeals
+  class Repo
+    class Git < BetweenMeals::Repo
+    end
+    class Hg < BetweenMeals::Repo
+    end
+    class Svn < BetweenMeals::Repo
+    end
+  end
+end


### PR DESCRIPTION
This is to allow checking of the types without bringing in all the dependencies of the repo implementations (eg. rugged from git).

In particular it should help [this check](https://github.com/facebook/taste-tester/blob/main/lib/taste_tester/commands.rb#L280) in `taste-tester` without rolling back [lazy loading of repo libraries](https://github.com/facebook/between-meals/commit/e02a7ca003f44a8ad801517b5c8074f0f4a33027)