### PR TITLE
[rspec] Only test rugged extension if rugged gem is available

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.5, 2.6, 2.7]
+        ruby: ["2.7", "3.0", "3.1"]
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository

--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,6 @@ group :development do
   gem 'rspec-core', '~> 3.11'
   gem 'rspec-expectations', '~> 3.11'
   gem 'rspec-mocks', '~> 3.11'
-  gem 'rubocop', '= 1.3.1'
+  gem 'rubocop', '= 1.25.1'
   gem 'simplecov'
 end

--- a/between_meals.gemspec
+++ b/between_meals.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   s.files = %w{README.md LICENSE} +
     Dir.glob('lib/**/*', File::FNM_DOTMATCH).reject { |f| File.directory?(f) }
 
-  s.required_ruby_version = '>= 2.5.0'
+  s.required_ruby_version = '>= 2.7.0'
   s.add_dependency 'colorize'
   s.add_dependency 'mixlib-shellout'
 end

--- a/spec/git_spec.rb
+++ b/spec/git_spec.rb
@@ -15,6 +15,14 @@
 # limitations under the License.
 
 require 'spec_helper'
+
+# Test if rugged gem is available, skip tests if not
+begin
+  require 'rugged'
+rescue LoadError
+  return
+end
+
 require 'between_meals/repo/git'
 require 'between_meals/repo.rb'
 require 'logger'


### PR DESCRIPTION
While we still want to keep testing `rugged` on the Github CI, it's not necessary everywhere (and building rugged is a PITA).