### PR TITLE
[#create_databag_if_missing] Remove preceding log message before parsing JSON

### DIFF
--- a/lib/between_meals/knife.rb
+++ b/lib/between_meals/knife.rb
@@ -263,6 +263,8 @@ IAMAEpsWX2s2A6phgMCx7kH6wMmoZn3hb7Thh9+PfR8Jtp2/7k+ibCeF4gEWUCs5
       s = Mixlib::ShellOut.new("#{@knife} data bag list" +
                                ' --format json ' +
                                "-c #{@config}").run_command
+
+      s.stdout.gsub!(/^[A-Z].*\n/, '')
       s.error!
       db = JSON.parse(s.stdout)
       unless db.include?(databag)


### PR DESCRIPTION
Got a repro of #144. Let's remove the first line of the stdout if it's a logging message.