### PR TITLE
version bump to 0.0.13

### DIFF
--- a/between_meals.gemspec
+++ b/between_meals.gemspec
@@ -16,7 +16,7 @@
 
 Gem::Specification.new do |s|
   s.name = 'between_meals'
-  s.version = '0.0.12'
+  s.version = '0.0.13'
   s.summary = 'Between Meals'
   s.description = 'Library for calculating Chef differences between revisions'
   s.license = 'Apache-2.0'


### PR DESCRIPTION
It's been ~5 years since we've cut a gem, and as I found out from #144 there are downstream users using rubygems.org to get this. Doing a version bump so I can publish a new gem