### PR TITLE
[between-meals] Add Sapling support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ Between Meals is the library for calculating what Chef objects were modified
 between two revisions in a version control system. It is also the library
 that backs Taste Tester and Grocery Delivery.
 
-It currently supports SVN, GIT and HG, but plugins can easily be written for
-other source control systems.
+It currently supports Sapling, SVN, GIT and HG, but plugins can easily be
+written for other source control systems.
 
 It also includes some wrappers around knife execution and a few other utility
 functions.

--- a/lib/between_meals/repo.rb
+++ b/lib/between_meals/repo.rb
@@ -39,6 +39,7 @@ module BetweenMeals
         end
         logger.info('Trying to detect repo type')
         {
+          'Sapling' => 'between_meals/repo/sapling',
           'Hg' => 'between_meals/repo/hg',
           'Svn' => 'between_meals/repo/svn',
           'Git' => 'between_meals/repo/git',
@@ -56,6 +57,9 @@ module BetweenMeals
         end
         logger.warn("Failed detecting repo type at #{repo_path}")
         exit(1)
+      when 'sapling'
+        require 'between_meals/repo/sapling'
+        BetweenMeals::Repo::Sapling.new(repo_path, logger)
       when 'hg'
         require 'between_meals/repo/hg'
         BetweenMeals::Repo::Hg.new(repo_path, logger)

--- a/lib/between_meals/repo/sapling.rb
+++ b/lib/between_meals/repo/sapling.rb
@@ -1,0 +1,212 @@
+# Copyright (c) 2026-present, Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'pathname'
+require 'mixlib/shellout'
+require 'between_meals/changeset'
+require 'between_meals/repo/sapling/cmd'
+
+module BetweenMeals
+  class Repo
+    class Sapling < BetweenMeals::Repo
+      def setup
+        @bin = 'sl'
+        @cmd = BetweenMeals::Repo::Sapling::Cmd.new(
+          :bin => @bin,
+          :cwd => @repo_path,
+          :logger => @logger,
+        )
+      end
+
+      def exists?
+        Dir.exist?(Pathname.new(@repo_path).join('.sl'))
+      end
+
+      def head_rev
+        @cmd.log('node').stdout
+      end
+
+      def checkout(url)
+        @cmd.clone(url, @repo_path)
+      end
+
+      # Return files changed between two revisions
+      def changes(start_ref, end_ref)
+        valid_ref?(start_ref)
+        valid_ref?(end_ref) if end_ref
+        stdout = @cmd.status(start_ref, end_ref).stdout
+        begin
+          parse_status(stdout).compact
+        rescue StandardError => e
+          # We've seen some weird non-reproducible failures here
+          @logger.error(
+            'Something went wrong. Please report this output.',
+          )
+          @logger.error(e)
+          stdout.lines.each do |line|
+            @logger.error(line.strip)
+          end
+          exit(1)
+        end
+      end
+
+      def update
+        @cmd.pull.stdout
+      rescue StandardError => e
+        @logger.error('Something went wrong with sapling!')
+        @logger.error(e)
+        raise
+      end
+
+      # Return all files
+      def files
+        @cmd.manifest.stdout.split("\n").map do |x|
+          { :path => x, :status => :created }
+        end
+      end
+
+      def head_parents
+        [{
+          :time => Time.parse(@cmd.log('date|isodate', 'master').stdout),
+          :rev => @cmd.log('node', 'master').stdout,
+        }]
+      rescue StandardError
+        [{
+          :time => nil,
+          :rev => nil,
+        }]
+      end
+
+      def last_author
+        [
+          /^.*<(.*)>$/,
+          /^(.*@.*)$/,
+        ].each do |re|
+          m = @cmd.log('author').stdout.match(re)
+          return { :email => m[1] } if m
+        end
+        return { :email => nil }
+      end
+
+      def last_msg
+        @cmd.log('desc').stdout
+      rescue StandardError
+        nil
+      end
+
+      def last_msg=(msg)
+        if last_msg.strip != msg.strip
+          @cmd.amend(msg.strip)
+        end
+      end
+
+      def email
+        username[2]
+      rescue StandardError
+        nil
+      end
+
+      def name
+        username[1]
+      rescue StandardError
+        nil
+      end
+
+      def status
+        @cmd.status.stdout
+      end
+
+      def upstream?(rev)
+        # Check if commit is an ancestor of master
+        # Returns the diff if common ancestor is found,
+        # returns nothing if not
+        if @cmd.rev("'ancestor(master,#{rev}) & #{rev}'").stdout.empty?
+          return false
+        else
+          return true
+        end
+      end
+
+      def valid_ref?(ref)
+        @cmd.rev(ref)
+        return true
+      rescue StandardError
+        raise Changeset::ReferenceError
+      end
+
+      private
+
+      def username
+        @cmd.username.stdout.lines.first.strip.match(/^(.*?)(?:\s<(.*)>)?$/)
+      end
+
+      def parse_status(changes)
+        # The codes used to show the status of files are:
+        #
+        #  M = modified
+        #  A = added
+        #  R = removed
+        #  C = clean
+        #  ! = missing (deleted by non-hg command, but still tracked)
+        #  ? = not tracked
+        #  I = ignored
+        #    = origin of the previous file (with --copies)
+
+        changes.lines.map do |line|
+          parts = line.chomp.split(nil, 2)
+          case parts[0]
+          when 'A'
+            {
+              :status => :added,
+              :path => parts[1],
+            }
+          when 'C'
+            {
+              :status => :clean,
+              :path => parts[1],
+            }
+          when 'R'
+            {
+              :status => :deleted,
+              :path => parts[1],
+            }
+          when 'M'
+            {
+              :status => :modified,
+              :path => parts[1],
+            }
+          when '!'
+            {
+              :status => :missing,
+              :path => parts[1],
+            }
+          when '?'
+            {
+              :status => :untracked,
+              :path => parts[1],
+            }
+          when 'I'
+            {
+              :status => :ignored,
+              :path => parts[1],
+            }
+          else
+            fail 'Failed to parse repo diff line.'
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/between_meals/repo/sapling/cmd.rb
+++ b/lib/between_meals/repo/sapling/cmd.rb
@@ -1,0 +1,71 @@
+# Copyright (c) 2026-present, Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'between_meals/cmd'
+require 'tempfile'
+
+module BetweenMeals
+  class Repo
+    class Sapling < ::BetweenMeals::Repo
+      class Cmd < ::BetweenMeals::Cmd
+        def rev(rev)
+          cmd("log -r #{rev}")
+        end
+
+        def log(template, rev = '.')
+          cmd("log -r #{rev} -l 1 -T '{#{template}}'")
+        end
+
+        def clone(url, repo_path)
+          cmd("clone #{url} #{repo_path}")
+        end
+
+        def pull
+          cmd('pull --rebase')
+        end
+
+        def manifest
+          cmd('manifest')
+        end
+
+        def username
+          cmd('config ui.username')
+        end
+
+        def amend(msg)
+          f = Tempfile.new('between_meals.sapling.amend')
+          begin
+            f.write(msg)
+            f.flush
+            cmd("commit --amend --exclude '**' -l #{f.path}")
+          ensure
+            f.close
+            f.unlink
+          end
+        end
+
+        def status(start_ref = nil, end_ref = nil)
+          if start_ref && end_ref
+            cmd("status --rev #{start_ref} --rev #{end_ref}")
+          elsif start_ref
+            cmd("status --rev #{start_ref}")
+          else
+            cmd('status')
+          end
+        end
+      end
+    end
+  end
+end

--- a/sig/generated/between_meals/repo/sapling.rbs
+++ b/sig/generated/between_meals/repo/sapling.rbs
@@ -1,0 +1,61 @@
+# Copyright (c) 2026-present, Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Generated from lib/between_meals/repo/sapling.rb with RBS::Inline
+
+module BetweenMeals
+  class Repo
+    class Sapling < BetweenMeals::Repo
+      def setup: () -> untyped
+
+      def exists?: () -> untyped
+
+      def head_rev: () -> untyped
+
+      def checkout: (untyped url) -> untyped
+
+      # Return files changed between two revisions
+      def changes: (untyped start_ref, untyped end_ref) -> untyped
+
+      def update: () -> untyped
+
+      # Return all files
+      def files: () -> untyped
+
+      def head_parents: () -> untyped
+
+      def last_author: () -> untyped
+
+      def last_msg: () -> untyped
+
+      def last_msg=: (untyped msg) -> untyped
+
+      def email: () -> untyped
+
+      def name: () -> untyped
+
+      def status: () -> untyped
+
+      def upstream?: (untyped rev) -> untyped
+
+      def valid_ref?: (untyped ref) -> untyped
+
+      private
+
+      def username: () -> untyped
+
+      def parse_status: (untyped changes) -> untyped
+    end
+  end
+end

--- a/sig/generated/between_meals/repo/sapling/cmd.rbs
+++ b/sig/generated/between_meals/repo/sapling/cmd.rbs
@@ -1,0 +1,39 @@
+# Copyright (c) 2026-present, Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Generated from lib/between_meals/repo/sapling/cmd.rb with RBS::Inline
+
+module BetweenMeals
+  class Repo
+    class Sapling < ::BetweenMeals::Repo
+      class Cmd < ::BetweenMeals::Cmd
+        def rev: (untyped rev) -> untyped
+
+        def log: (untyped template, ?untyped rev) -> untyped
+
+        def clone: (untyped url, untyped repo_path) -> untyped
+
+        def pull: () -> untyped
+
+        def manifest: () -> untyped
+
+        def username: () -> untyped
+
+        def amend: (untyped msg) -> untyped
+
+        def status: (?untyped start_ref, ?untyped end_ref) -> untyped
+      end
+    end
+  end
+end

--- a/spec/sapling_spec.rb
+++ b/spec/sapling_spec.rb
@@ -1,0 +1,156 @@
+# Copyright (c) 2026-present, Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'spec_helper'
+require 'between_meals/repo/sapling'
+require 'between_meals/repo.rb'
+require 'logger'
+require_relative 'repo_subclass_conformance'
+
+describe BetweenMeals::Repo::Sapling do
+  context 'conforms to BetweenMeals::Repo interfaces' do
+    it_behaves_like 'Repo subclass conformance', BetweenMeals::Repo::Sapling
+  end
+  let(:logger) do
+    Logger.new('/dev/null')
+  end
+
+  examples = [
+    {
+      :name => 'empty filelists',
+      :changes => '',
+      :result => [],
+    },
+    {
+      :name => 'handle additions',
+      :changes => 'A bar/baz',
+      :result => [
+        { :status => :added, :path => 'bar/baz' },
+      ],
+    },
+    {
+      :name => 'handle additions with spaces',
+      :changes => 'A bar/baz bot',
+      :result => [
+        { :status => :added, :path => 'bar/baz bot' },
+      ],
+    },
+    {
+      :name => 'handle deletes',
+      :changes => 'R bar/baz',
+      :result => [
+        { :status => :deleted, :path => 'bar/baz' },
+      ],
+    },
+    {
+      :name => 'handle deletes with spaces',
+      :changes => 'R bar/baz bot',
+      :result => [
+        { :status => :deleted, :path => 'bar/baz bot' },
+      ],
+    },
+    {
+      :name => 'handle modifications',
+      :changes => 'M bar/baz',
+      :result => [
+        { :status => :modified, :path => 'bar/baz' },
+      ],
+    },
+    {
+      :name => 'handle modifications with spaces',
+      :changes => 'M bar/baz bot',
+      :result => [
+        { :status => :modified, :path => 'bar/baz bot' },
+      ],
+    },
+    {
+      :name => 'handle clean',
+      :changes => 'C bar/baz',
+      :result => [
+        { :status => :clean, :path => 'bar/baz' },
+      ],
+    },
+    {
+      :name => 'handle missing',
+      :changes => '! bar/baz',
+      :result => [
+        { :status => :missing, :path => 'bar/baz' },
+      ],
+    },
+    {
+      :name => 'handle untracked',
+      :changes => '? bar/baz',
+      :result => [
+        { :status => :untracked, :path => 'bar/baz' },
+      ],
+    },
+    {
+      :name => 'handle ignored',
+      :changes => 'I bar/baz',
+      :result => [
+        { :status => :ignored, :path => 'bar/baz' },
+      ],
+    },
+  ]
+
+  examples.each do |fixture|
+    it "should handle #{fixture[:name]}" do
+      allow_any_instance_of(BetweenMeals::Repo::Sapling).
+        to receive(:setup).and_return(true)
+      sapling = BetweenMeals::Repo::Sapling.new('foo', logger)
+      expect(sapling.send(:parse_status, fixture[:changes])).
+        to eq(fixture[:result])
+    end
+  end
+
+  examples = [
+    {
+      :config => 'baz <foo@bar.com>',
+      :name => 'baz',
+      :email => 'foo@bar.com',
+    },
+    {
+      :config => 'bar',
+      :name => 'bar',
+      :email => nil,
+    },
+    {
+      :config => '',
+      :name => nil,
+      :email => nil,
+    },
+  ]
+
+  examples.each do |example|
+    it 'should read config' do
+      cmd = double(Mixlib::ShellOut, :stdout => example[:config])
+      allow_any_instance_of(BetweenMeals::Cmd).
+        to receive(:cmd).and_return(cmd)
+
+      sapling = BetweenMeals::Repo::Sapling.new('foo', logger)
+      expect(sapling.email).to eq(example[:email])
+      expect(sapling.name).to eq(example[:name])
+    end
+  end
+
+  it 'should handle malformed output' do
+    allow_any_instance_of(BetweenMeals::Repo::Sapling).
+      to receive(:setup).and_return(true)
+    sapling = BetweenMeals::Repo::Sapling.new('foo', logger)
+    expect(lambda do
+      sapling.send(:parse_status, 'HGFS djs/ dsd)')
+    end).to raise_error('Failed to parse repo diff line.')
+  end
+end


### PR DESCRIPTION
Summary:
Add Sapling (sl) as a supported VCS, mirroring the existing Hg implementation. Deliberately not sub-classing Hg, since there's no guarantee behaviour will remain consistent over time. Sapling uses the `.sl` directory and `sl` binary. Auto-detection checks for Sapling before Hg so it takes precedence.

Test Plan:
/opt/chef-workstation/embedded/bin/rspec - 89 examples, 0 failures